### PR TITLE
Provisioning `3.143`

### DIFF
--- a/packages/clean_setup/clean_setup_customizations.xml
+++ b/packages/clean_setup/clean_setup_customizations.xml
@@ -3,10 +3,10 @@
   <PackageConfig xmlns="urn:schemas-Microsoft-com:Windows-ICD-Package-Config.v1.0">
     <ID>{a8dd246b-bb6f-4ba6-8664-a64444424b8a}</ID>
     <Name>Clean Setup</Name>
-    <Version>3.142</Version>
+    <Version>3.143</Version>
     <OwnerType>ITAdmin</OwnerType>
     <Rank>40</Rank>
-    <Notes>Updates OneDrive and Edge, and installs PowerShellCore, Windows Terminal, and AV1, HEIF, HEVC, and VP9 Video Extensions on all computers. Installs Intel Drivers and Chrome on the Alienware Aurora, and Surface Laptop 3. All files are up-to-date as of 1/16/2022.</Notes>
+    <Notes>Updates OneDrive and Edge, and installs PowerShellCore, Windows Terminal, and AV1, HEIF, HEVC, and VP9 Video Extensions on all computers. Installs Intel Drivers and Chrome on the Alienware Aurora, and Surface Laptop 3. All files are up-to-date as of 1/23/2022.</Notes>
   </PackageConfig>
   <Settings xmlns="urn:schemas-microsoft-com:windows-provisioning">
     <Customizations>
@@ -32,9 +32,9 @@
           </DeviceContext>
           <PrimaryContext>
             <Command>
-              <CommandConfig Name="Microsoft_Edge_97.0.1072.62">
-                <CommandFile>C:\provisioning\software\general\MicrosoftEdgeEnterpriseX64-97.0.1072.62.msi</CommandFile>
-                <CommandLine>msiexec /i "microsoftedgeenterprisex64-97.0.1072.62.msi" /passive</CommandLine>
+              <CommandConfig Name="Microsoft_Edge_97.0.1072.69">
+                <CommandFile>C:\provisioning\software\general\MicrosoftEdgeEnterpriseX64-97.0.1072.69.msi</CommandFile>
+                <CommandLine>msiexec /i "microsoftedgeenterprisex64-97.0.1072.69.msi" /passive</CommandLine>
                 <ContinueInstall>True</ContinueInstall>
                 <RestartRequired>False</RestartRequired>
                 <ReturnCodeRestart>3010</ReturnCodeRestart>
@@ -48,17 +48,17 @@
                 <ReturnCodeRestart>3010</ReturnCodeRestart>
                 <ReturnCodeSuccess>0</ReturnCodeSuccess>
               </CommandConfig>
-              <CommandConfig Name="OneDrive_22.002.0103.0002">
-                <CommandFile>C:\provisioning\software\general\OneDriveSetup-22.002.0103.0002.exe</CommandFile>
-                <CommandLine>cmd /c "onedrivesetup-22.002.0103.0002.exe" /allusers /passive</CommandLine>
+              <CommandConfig Name="OneDrive_22.007.0109.0002">
+                <CommandFile>C:\provisioning\software\general\OneDriveSetup-22.007.0109.0002.exe</CommandFile>
+                <CommandLine>cmd /c "onedrivesetup-22.007.0109.0002.exe" /allusers /passive</CommandLine>
                 <ContinueInstall>True</ContinueInstall>
                 <RestartRequired>False</RestartRequired>
                 <ReturnCodeRestart>3010</ReturnCodeRestart>
                 <ReturnCodeSuccess>0</ReturnCodeSuccess>
               </CommandConfig>
-              <CommandConfig Name="Google_Chrome_97.0.4692.71">
-                <CommandFile>C:\provisioning\software\general\GoogleChromeStandaloneEnterprise64-97.0.4692.71.msi</CommandFile>
-                <CommandLine>msiexec /i "googlechromestandaloneenterprise64-97.0.4692.71.msi" /passive</CommandLine>
+              <CommandConfig Name="Google_Chrome_97.0.4692.99">
+                <CommandFile>C:\provisioning\software\general\GoogleChromeStandaloneEnterprise64-97.0.4692.99.msi</CommandFile>
+                <CommandLine>msiexec /i "googlechromestandaloneenterprise64-97.0.4692.99.msi" /passive</CommandLine>
                 <ContinueInstall>True</ContinueInstall>
                 <RestartRequired>False</RestartRequired>
                 <ReturnCodeRestart>3010</ReturnCodeRestart>
@@ -122,25 +122,25 @@
       <Targets>
         <Target Id="Surface Laptop 3">
           <TargetState>
-            <Condition Name="ProcessorName" Value="Pattern:.*1065(G|g)7.*" />
+            <Condition Name="ProcessorName" Value="Pattern:.*1065(G|g)7.*"/>
           </TargetState>
         </Target>
         <Target Id="Aurora">
           <TargetState>
-            <Condition Name="ProcessorName" Value="Pattern:.*9700.*" />
+            <Condition Name="ProcessorName" Value="Pattern:.*9700.*"/>
           </TargetState>
         </Target>
         <Target Id="Professional">
           <TargetState>
-            <Condition Name="Edition" Value="Pattern:.*(P|p)ro.*" />
+            <Condition Name="Edition" Value="Pattern:.*(P|p)ro.*"/>
           </TargetState>
         </Target>
       </Targets>
       <Variant>
         <TargetRefs>
-          <TargetRef Id="Professional" />
-          <TargetRef Id="Aurora" />
-          <TargetRef Id="Surface Laptop 3" />
+          <TargetRef Id="Professional"/>
+          <TargetRef Id="Aurora"/>
+          <TargetRef Id="Surface Laptop 3"/>
         </TargetRefs>
         <Settings>
           <Policies>
@@ -152,7 +152,7 @@
       </Variant>
       <Variant>
         <TargetRefs>
-          <TargetRef Id="Aurora" />
+          <TargetRef Id="Aurora"/>
         </TargetRefs>
         <Settings>
           <DevDetail>
@@ -166,9 +166,9 @@
           <ProvisioningCommands>
             <PrimaryContext>
               <Command>
-                <CommandConfig Name="Microsoft_Edge_97.0.1072.62">
-                  <CommandFile>C:\provisioning\software\general\MicrosoftEdgeEnterpriseX64-97.0.1072.62.msi</CommandFile>
-                  <CommandLine>msiexec /i "microsoftedgeenterprisex64-97.0.1072.62.msi" /passive</CommandLine>
+                <CommandConfig Name="Microsoft_Edge_97.0.1072.69">
+                  <CommandFile>C:\provisioning\software\general\MicrosoftEdgeEnterpriseX64-97.0.1072.69.msi</CommandFile>
+                  <CommandLine>msiexec /i "microsoftedgeenterprisex64-97.0.1072.69.msi" /passive</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
@@ -182,17 +182,17 @@
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="OneDrive_22.002.0103.0002">
-                  <CommandFile>C:\provisioning\software\general\OneDriveSetup-22.002.0103.0002.exe</CommandFile>
-                  <CommandLine>cmd /c "onedrivesetup-22.002.0103.0002.exe" /allusers /passive</CommandLine>
+                <CommandConfig Name="OneDrive_22.007.0109.0002">
+                  <CommandFile>C:\provisioning\software\general\OneDriveSetup-22.007.0109.0002.exe</CommandFile>
+                  <CommandLine>cmd /c "onedrivesetup-22.007.0109.0002.exe" /allusers /passive</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Google_Chrome_97.0.4692.71">
-                  <CommandFile>C:\provisioning\software\general\GoogleChromeStandaloneEnterprise64-97.0.4692.71.msi</CommandFile>
-                  <CommandLine>msiexec /i "googlechromestandaloneenterprise64-97.0.4692.71.msi" /passive</CommandLine>
+                <CommandConfig Name="Google_Chrome_97.0.4692.99">
+                  <CommandFile>C:\provisioning\software\general\GoogleChromeStandaloneEnterprise64-97.0.4692.99.msi</CommandFile>
+                  <CommandLine>msiexec /i "googlechromestandaloneenterprise64-97.0.4692.99.msi" /passive</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
@@ -269,7 +269,7 @@
       </Variant>
       <Variant>
         <TargetRefs>
-          <TargetRef Id="Surface Laptop 3" />
+          <TargetRef Id="Surface Laptop 3"/>
         </TargetRefs>
         <Settings>
           <DevDetail>
@@ -283,9 +283,9 @@
           <ProvisioningCommands>
             <PrimaryContext>
               <Command>
-                <CommandConfig Name="Microsoft_Edge_97.0.1072.62">
-                  <CommandFile>C:\provisioning\software\general\MicrosoftEdgeEnterpriseX64-97.0.1072.62.msi</CommandFile>
-                  <CommandLine>msiexec /i "microsoftedgeenterprisex64-97.0.1072.62.msi" /passive</CommandLine>
+                <CommandConfig Name="Microsoft_Edge_97.0.1072.69">
+                  <CommandFile>C:\provisioning\software\general\MicrosoftEdgeEnterpriseX64-97.0.1072.69.msi</CommandFile>
+                  <CommandLine>msiexec /i "microsoftedgeenterprisex64-97.0.1072.69.msi" /passive</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
@@ -299,17 +299,17 @@
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="OneDrive_22.002.0103.0002">
-                  <CommandFile>C:\provisioning\software\general\OneDriveSetup-22.002.0103.0002.exe</CommandFile>
-                  <CommandLine>cmd /c "onedrivesetup-22.002.0103.0002.exe" /allusers /passive</CommandLine>
+                <CommandConfig Name="OneDrive_22.007.0109.0002">
+                  <CommandFile>C:\provisioning\software\general\OneDriveSetup-22.007.0109.0002.exe</CommandFile>
+                  <CommandLine>cmd /c "onedrivesetup-22.007.0109.0002.exe" /allusers /passive</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Google_Chrome_97.0.4692.71">
-                  <CommandFile>C:\provisioning\software\general\GoogleChromeStandaloneEnterprise64-97.0.4692.71.msi</CommandFile>
-                  <CommandLine>msiexec /i "googlechromestandaloneenterprise64-97.0.4692.71.msi" /passive</CommandLine>
+                <CommandConfig Name="Google_Chrome_97.0.4692.99">
+                  <CommandFile>C:\provisioning\software\general\GoogleChromeStandaloneEnterprise64-97.0.4692.99.msi</CommandFile>
+                  <CommandLine>msiexec /i "googlechromestandaloneenterprise64-97.0.4692.99.msi" /passive</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>

--- a/packages/gci_air_gap/gci_air_gap_customizations.xml
+++ b/packages/gci_air_gap/gci_air_gap_customizations.xml
@@ -3,10 +3,10 @@
   <PackageConfig xmlns="urn:schemas-Microsoft-com:Windows-ICD-Package-Config.v1.0">
     <ID>{34c0eb4c-1c46-5d44-b9eb-9e49f2a054a8}</ID>
     <Name>GCI Air Gap</Name>
-    <Version>3.142</Version>
+    <Version>3.143</Version>
     <OwnerType>ITAdmin</OwnerType>
     <Rank>60</Rank>
-    <Notes>Made specifically for the GCI Air Gap Lab. Installs Chrome, PowerShellCore, and Windows Terminal. All files are up-to-date as of 1/16/2022.</Notes>
+    <Notes>Made specifically for the GCI Air Gap Lab. Installs Chrome, PowerShellCore, and Windows Terminal. All files are up-to-date as of 1/23/2022.</Notes>
   </PackageConfig>
   <Settings xmlns="urn:schemas-microsoft-com:windows-provisioning">
     <Customizations>
@@ -21,9 +21,9 @@
           </DeviceContext>
           <PrimaryContext>
             <Command>
-              <CommandConfig Name="Microsoft_Edge_97.0.1072.62">
-                <CommandFile>C:\provisioning\software\general\MicrosoftEdgeEnterpriseX64-97.0.1072.62.msi</CommandFile>
-                <CommandLine>msiexec /i "microsoftedgeenterprisex64-97.0.1072.62.msi" /passive</CommandLine>
+              <CommandConfig Name="Microsoft_Edge_97.0.1072.69">
+                <CommandFile>C:\provisioning\software\general\MicrosoftEdgeEnterpriseX64-97.0.1072.69.msi</CommandFile>
+                <CommandLine>msiexec /i "microsoftedgeenterprisex64-97.0.1072.69.msi" /passive</CommandLine>
                 <ContinueInstall>True</ContinueInstall>
                 <RestartRequired>False</RestartRequired>
                 <ReturnCodeRestart>3010</ReturnCodeRestart>
@@ -37,9 +37,9 @@
                 <ReturnCodeRestart>3010</ReturnCodeRestart>
                 <ReturnCodeSuccess>0</ReturnCodeSuccess>
               </CommandConfig>
-              <CommandConfig Name="Google_Chrome_97.0.4692.71">
-                <CommandFile>C:\provisioning\software\general\GoogleChromeStandaloneEnterprise64-97.0.4692.71.msi</CommandFile>
-                <CommandLine>msiexec /i "googlechromestandaloneenterprise64-97.0.4692.71.msi" /passive</CommandLine>
+              <CommandConfig Name="Google_Chrome_97.0.4692.99">
+                <CommandFile>C:\provisioning\software\general\GoogleChromeStandaloneEnterprise64-97.0.4692.99.msi</CommandFile>
+                <CommandLine>msiexec /i "googlechromestandaloneenterprise64-97.0.4692.99.msi" /passive</CommandLine>
                 <ContinueInstall>True</ContinueInstall>
                 <RestartRequired>False</RestartRequired>
                 <ReturnCodeRestart>3010</ReturnCodeRestart>

--- a/packages/netlab_core/netlab_core_customizations.xml
+++ b/packages/netlab_core/netlab_core_customizations.xml
@@ -3,10 +3,10 @@
   <PackageConfig xmlns="urn:schemas-Microsoft-com:Windows-ICD-Package-Config.v1.0">
     <ID>{a8dd246b-bb6f-4ba6-8664-a64444424b8e}</ID>
     <Name>NetLab Core</Name>
-    <Version>3.142</Version>
+    <Version>3.143</Version>
     <OwnerType>ITAdmin</OwnerType>
     <Rank>60</Rank>
-    <Notes>Made specifically for NetLab. Installs Chrome, PowerShellCore, and Windows Terminal. All files are up-to-date as of 1/16/2022.</Notes>
+    <Notes>Made specifically for NetLab. Installs Chrome, PowerShellCore, and Windows Terminal. All files are up-to-date as of 1/23/2022.</Notes>
   </PackageConfig>
   <Settings xmlns="urn:schemas-microsoft-com:windows-provisioning">
     <Customizations>
@@ -29,9 +29,9 @@
                 <ReturnCodeRestart>3010</ReturnCodeRestart>
                 <ReturnCodeSuccess>0</ReturnCodeSuccess>
               </CommandConfig>
-              <CommandConfig Name="Google_Chrome_97.0.4692.71">
-                <CommandFile>C:\provisioning\software\general\GoogleChromeStandaloneEnterprise64-97.0.4692.71.msi</CommandFile>
-                <CommandLine>msiexec /i "googlechromestandaloneenterprise64-97.0.4692.71.msi" /passive</CommandLine>
+              <CommandConfig Name="Google_Chrome_97.0.4692.99">
+                <CommandFile>C:\provisioning\software\general\GoogleChromeStandaloneEnterprise64-97.0.4692.99.msi</CommandFile>
+                <CommandLine>msiexec /i "googlechromestandaloneenterprise64-97.0.4692.99.msi" /passive</CommandLine>
                 <ContinueInstall>True</ContinueInstall>
                 <RestartRequired>False</RestartRequired>
                 <ReturnCodeRestart>3010</ReturnCodeRestart>

--- a/packages/terminal_plus/terminal_plus_customizations.xml
+++ b/packages/terminal_plus/terminal_plus_customizations.xml
@@ -3,10 +3,10 @@
   <PackageConfig xmlns="urn:schemas-Microsoft-com:Windows-ICD-Package-Config.v1.0">
     <ID>{a8dd246b-bb6f-4ba6-8664-a64444424b8c}</ID>
     <Name>Terminal+</Name>
-    <Version>3.142</Version>
+    <Version>3.143</Version>
     <OwnerType>ITAdmin</OwnerType>
     <Rank>20</Rank>
-    <Notes>Updates OneDrive and Edge, and installs Chrome, PowerShellCore, Windows Terminal, and AV1, HEIF, HEVC, and VP9 Video Extensions on all computers. Removes legacy Edge, 3DViewer, and Mixed Reality Portal. All files are up-to-date as of 1/16/2022.</Notes>
+    <Notes>Updates OneDrive and Edge, and installs Chrome, PowerShellCore, Windows Terminal, and AV1, HEIF, HEVC, and VP9 Video Extensions on all computers. Removes legacy Edge, 3DViewer, and Mixed Reality Portal. All files are up-to-date as of 1/23/2022.</Notes>
   </PackageConfig>
   <Settings xmlns="urn:schemas-microsoft-com:windows-provisioning">
     <Customizations>
@@ -21,9 +21,9 @@
           </DeviceContext>
           <PrimaryContext>
             <Command>
-              <CommandConfig Name="Microsoft_Edge_97.0.1072.62">
-                <CommandFile>C:\provisioning\software\general\MicrosoftEdgeEnterpriseX64-97.0.1072.62.msi</CommandFile>
-                <CommandLine>msiexec /i "microsoftedgeenterprisex64-97.0.1072.62.msi" /passive</CommandLine>
+              <CommandConfig Name="Microsoft_Edge_97.0.1072.69">
+                <CommandFile>C:\provisioning\software\general\MicrosoftEdgeEnterpriseX64-97.0.1072.69.msi</CommandFile>
+                <CommandLine>msiexec /i "microsoftedgeenterprisex64-97.0.1072.69.msi" /passive</CommandLine>
                 <ContinueInstall>True</ContinueInstall>
                 <RestartRequired>False</RestartRequired>
                 <ReturnCodeRestart>3010</ReturnCodeRestart>
@@ -37,17 +37,17 @@
                 <ReturnCodeRestart>3010</ReturnCodeRestart>
                 <ReturnCodeSuccess>0</ReturnCodeSuccess>
               </CommandConfig>
-              <CommandConfig Name="OneDrive_22.002.0103.0002">
-                <CommandFile>C:\provisioning\software\general\OneDriveSetup-22.002.0103.0002.exe</CommandFile>
-                <CommandLine>cmd /c "onedrivesetup-22.002.0103.0002.exe" /allusers /passive</CommandLine>
+              <CommandConfig Name="OneDrive_22.007.0109.0002">
+                <CommandFile>C:\provisioning\software\general\OneDriveSetup-22.007.0109.0002.exe</CommandFile>
+                <CommandLine>cmd /c "onedrivesetup-22.007.0109.0002.exe" /allusers /passive</CommandLine>
                 <ContinueInstall>True</ContinueInstall>
                 <RestartRequired>False</RestartRequired>
                 <ReturnCodeRestart>3010</ReturnCodeRestart>
                 <ReturnCodeSuccess>0</ReturnCodeSuccess>
               </CommandConfig>
-              <CommandConfig Name="Google_Chrome_97.0.4692.71">
-                <CommandFile>C:\provisioning\software\general\GoogleChromeStandaloneEnterprise64-97.0.4692.71.msi</CommandFile>
-                <CommandLine>msiexec /i "googlechromestandaloneenterprise64-97.0.4692.71.msi" /passive</CommandLine>
+              <CommandConfig Name="Google_Chrome_97.0.4692.99">
+                <CommandFile>C:\provisioning\software\general\GoogleChromeStandaloneEnterprise64-97.0.4692.99.msi</CommandFile>
+                <CommandLine>msiexec /i "googlechromestandaloneenterprise64-97.0.4692.99.msi" /passive</CommandLine>
                 <ContinueInstall>True</ContinueInstall>
                 <RestartRequired>False</RestartRequired>
                 <ReturnCodeRestart>3010</ReturnCodeRestart>

--- a/packages/vm_core/vm_core_customizations.xml
+++ b/packages/vm_core/vm_core_customizations.xml
@@ -3,10 +3,10 @@
   <PackageConfig xmlns="urn:schemas-Microsoft-com:Windows-ICD-Package-Config.v1.0">
     <ID>{a8dd246b-bb6f-4ba6-8664-a64444424b8d}</ID>
     <Name>Virtual Machine Core</Name>
-    <Version>3.142</Version>
+    <Version>3.143</Version>
     <OwnerType>ITAdmin</OwnerType>
     <Rank>60</Rank>
-    <Notes>Made specifically for Virtual Machines. Updates OneDrive and Edge, and installs Chrome, PowerShellCore, Windows Terminal, and AV1, HEIF, HEVC, and VP9 Video Extensions. Removes lots of provisioned apps including legacy Edge, 3DViewer, and Mixed Reality Portal. All files are up-to-date as of 1/16/2022.</Notes>
+    <Notes>Made specifically for Virtual Machines. Updates OneDrive and Edge, and installs Chrome, PowerShellCore, Windows Terminal, and AV1, HEIF, HEVC, and VP9 Video Extensions. Removes lots of provisioned apps including legacy Edge, 3DViewer, and Mixed Reality Portal. All files are up-to-date as of 1/23/2022.</Notes>
   </PackageConfig>
   <Settings xmlns="urn:schemas-microsoft-com:windows-provisioning">
     <Customizations>
@@ -21,9 +21,9 @@
           </DeviceContext>
           <PrimaryContext>
             <Command>
-              <CommandConfig Name="Microsoft_Edge_97.0.1072.62">
-                <CommandFile>C:\provisioning\software\general\MicrosoftEdgeEnterpriseX64-97.0.1072.62.msi</CommandFile>
-                <CommandLine>msiexec /i "microsoftedgeenterprisex64-97.0.1072.62.msi" /passive</CommandLine>
+              <CommandConfig Name="Microsoft_Edge_97.0.1072.69">
+                <CommandFile>C:\provisioning\software\general\MicrosoftEdgeEnterpriseX64-97.0.1072.69.msi</CommandFile>
+                <CommandLine>msiexec /i "microsoftedgeenterprisex64-97.0.1072.69.msi" /passive</CommandLine>
                 <ContinueInstall>True</ContinueInstall>
                 <RestartRequired>False</RestartRequired>
                 <ReturnCodeRestart>3010</ReturnCodeRestart>
@@ -37,17 +37,17 @@
                 <ReturnCodeRestart>3010</ReturnCodeRestart>
                 <ReturnCodeSuccess>0</ReturnCodeSuccess>
               </CommandConfig>
-              <CommandConfig Name="OneDrive_22.002.0103.0002">
-                <CommandFile>C:\provisioning\software\general\OneDriveSetup-22.002.0103.0002.exe</CommandFile>
-                <CommandLine>cmd /c "onedrivesetup-22.002.0103.0002.exe" /allusers /passive</CommandLine>
+              <CommandConfig Name="OneDrive_22.007.0109.0002">
+                <CommandFile>C:\provisioning\software\general\OneDriveSetup-22.007.0109.0002.exe</CommandFile>
+                <CommandLine>cmd /c "onedrivesetup-22.007.0109.0002.exe" /allusers /passive</CommandLine>
                 <ContinueInstall>True</ContinueInstall>
                 <RestartRequired>False</RestartRequired>
                 <ReturnCodeRestart>3010</ReturnCodeRestart>
                 <ReturnCodeSuccess>0</ReturnCodeSuccess>
               </CommandConfig>
-              <CommandConfig Name="Google_Chrome_97.0.4692.71">
-                <CommandFile>C:\provisioning\software\general\GoogleChromeStandaloneEnterprise64-97.0.4692.71.msi</CommandFile>
-                <CommandLine>msiexec /i "googlechromestandaloneenterprise64-97.0.4692.71.msi" /passive</CommandLine>
+              <CommandConfig Name="Google_Chrome_97.0.4692.99">
+                <CommandFile>C:\provisioning\software\general\GoogleChromeStandaloneEnterprise64-97.0.4692.99.msi</CommandFile>
+                <CommandLine>msiexec /i "googlechromestandaloneenterprise64-97.0.4692.99.msi" /passive</CommandLine>
                 <ContinueInstall>True</ContinueInstall>
                 <RestartRequired>False</RestartRequired>
                 <ReturnCodeRestart>3010</ReturnCodeRestart>


### PR DESCRIPTION
## Information

Release `3.143` of all provisioning packages affected by the updates below. (All packages except `Terminal`.)

### Updates

| Name | Version | Type |
| :------------- | :------------- | :------------- |
| Microsoft Edge  | `97.0.1072.69`  | Software |
| OneDrive | `22.007.0109.0002` | Software |
| Google Chrome  | `97.0.4692.99`  | Software |