### PR TITLE
Document Expand and Repair DISM Cmdlets and SFC Commands

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,11 +11,11 @@ You will find curated information that allows you to make intelligent decisions 
 A list of commands for working with Windows images, to extracting MSI executables, to getting a list of installed apps.
 This is not a comprehensive set of commands, but a curated set from Microsoft's expansive documentation.
 
-| Module          | Description                                                          |
-|:----------------|:---------------------------------------------------------------------|
-| [AppX](appx.md) | A set of commands for MSIX or AppX package management.               |
-| [DISM](dism.md) | A set of commands for modifying and analyzing Windows images (.wim). |
-| [MSI](msi.md)   | A set of commands for MSI package management.                        |
+| Module          | Description                                             |
+|:----------------|:--------------------------------------------------------|
+| [AppX](appx.md) | A set of commands for MSIX or AppX package management.  |
+| [DISM](dism.md) | A set of commands for servicing Windows images.         |
+| [MSI](msi.md)   | A set of commands for the Microsoft Windows Installer.  |
 
 ## Information
 
@@ -24,5 +24,5 @@ For example, a list of default Windows apps to inform you when deciding what you
 
 | Category                                               | Description                                                  |
 |:-------------------------------------------------------|:-------------------------------------------------------------|
-| [Provisioned Appx Packages](provisioned-appx-packages) | List of default apps included with Windows.                  |
+| [Provisioned Appx Packages](provisioned-appx-packages) | A list of the default apps included with Windows.            |
 | [Surface Laptop 3 Drivers](surface-laptop-3)           | A list of components in the Surface Laptop 3 driver package. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This is not a comprehensive set of commands, but a curated set from Microsoft's 
 | [AppX](appx.md) | A set of commands for MSIX or AppX package management.  |
 | [DISM](dism.md) | A set of commands for servicing Windows images.         |
 | [MSI](msi.md)   | A set of commands for the Microsoft Windows Installer.  |
+| [SFC](sfc.md)   | A set of commands for repairing protected system files. |
 
 ## Information
 

--- a/docs/dism.md
+++ b/docs/dism.md
@@ -106,6 +106,30 @@ Mount-WindowsImage -Path "C:\offline" -ImagePath "C:\provisioning\images\install
 ```shell
 Mount-WindowsImage -Path "C:\offline" -ImagePath "C:\provisioning\images\install.wim" -Index 1 -ReadOnly -CheckIntegrity
 ```
+## Repair-WindowsImage
+
+The **Repair-WindowsImage** cmdlet repairs a Windows image in a WIM or VHD file.
+For more information, see [Repair-WindowsImage](https://docs.microsoft.com/powershell/module/dism/repair-windowsimage).
+
+```shell
+Repair-WindowsImage -Path 'C:\offline' -CheckHealth
+```
+
+```shell
+Repair-WindowsImage -Path 'C:\offline' -ScanHealth
+```
+
+```shell
+Repair-WindowsImage -Path 'C:\offline' -RestoreHealth
+```
+
+```shell
+Repair-WindowsImage -Path "C:\offline" -StartComponentCleanup -ResetBase
+```
+
+```shell
+Repair-WindowsImage -Online -StartComponentCleanup -ResetBase
+```
 
 ## Split-WindowsImage
 

--- a/docs/dism.md
+++ b/docs/dism.md
@@ -24,6 +24,19 @@ Dismount-WindowsImage -Path "C:\offline" -Discard
 Dismount-WindowsImage -Path "C:\offline" -Save -CheckIntegrity
 ```
 
+## Expand-WindowsImage
+
+The **Expand-WindowsImage** cmdlet applies an image to a specified location.
+For more information, see [Expand-WindowsImage](https://docs.microsoft.com/powershell/module/dism/expand-windowsimage).
+
+```shell
+Expand-WindowsImage -ImagePath "C:\provisioning\images\install.wim" -Index 1 -ApplyPath "D:\" -CheckIntegrity -Verify
+```
+
+```shell
+Expand-WindowsImage -ImagePath "C:\provisioning\images\install.wim" -Name "Windows 11 Home" -ApplyPath "D:\" -CheckIntegrity -Verify
+```
+
 ## Export-WindowsImage
 
 The **Export-WindowsImage** cmdlet exports a copy of the specified image to another image file.

--- a/docs/dism.md
+++ b/docs/dism.md
@@ -1,6 +1,7 @@
-# DISM Cmdlets
+# Deployment Image Servicing and Management (DISM) Cmdlets
 
-A curated list of [Deployment Image Servicing and Management (DISM)](https://docs.microsoft.com/powershell/module/dism/) cmdlets.
+A curated list of [Deployment Image Servicing and Management](https://docs.microsoft.com/powershell/module/dism/) cmdlets.
+The Deployment Image Servicing and Management platform is used to mount and service Windows images.
 
 ## Clear-WindowsCorruptMountPoint
 
@@ -72,7 +73,7 @@ Get-AppxProvisionedPackage -Online
 ## Get-WindowsImage
 
 The **Get-WindowsImage** cmdlet gets information about a Windows image in a WIM or VHD file.
-For more information, see [Mount-WindowsImage](https://docs.microsoft.com/powershell/module/dism/get-windowsimage).
+For more information, see [Get-WindowsImage](https://docs.microsoft.com/powershell/module/dism/get-windowsimage).
 
 ```shell
 Get-WindowsImage -ImagePath "C:\provisioning\images\install.wim"

--- a/docs/msi.md
+++ b/docs/msi.md
@@ -1,6 +1,7 @@
-# Windows Installer (MSI) Commands
+# Microsoft Windows Installer (MSI) Commands
 
 A curated list of [Windows Installer](https://docs.microsoft.com/windows/win32/msi/windows-installer-portal) commands.
+The Microsoft Windows Installer service enables better corporate deployment and provides a standard format for component management.
 
 ## Unpacking MSI into Directory (TARGETDIR)
 

--- a/docs/sfc.md
+++ b/docs/sfc.md
@@ -1,0 +1,20 @@
+# System File Checker (SFC) Commands
+
+A curated list of [System File Checker](https://docs.microsoft.com/windows/win32/wfp/system-file-checker) commands.
+The System File Checker scans the integrity of all protected system files and repairs files with problems when possible.
+
+## Online Repair
+
+Repairs the running operating system on your local computer.
+
+```shell
+SFC /SCANNOW
+```
+
+## Offline Repair
+
+Repairs an offline operating system on an external drive.
+
+```shell
+SFC /SCANNOW /OFFBOOTDIR=D:\ /OFFWINDIR=D:\Windows /OFFLOGFILE=C:\provisioning\SFC-Log.txt
+```


### PR DESCRIPTION
# Summary

- Document more DISM Cmdlets
  - `Expand-WindowsImage`, applies a WIM to an empty formatted partition.
  - `Repair-WindowsImage`, repairs the component store on an online or offline windows image.
- Document SFC Commands
  - SFC Online and Offline Repair
- Minor refinements and fixes for documentation.