### PR TITLE
Update Dell Alienware Aurora R8 Drivers

### DIFF
--- a/packages/clean_setup/clean_setup_customizations.xml
+++ b/packages/clean_setup/clean_setup_customizations.xml
@@ -150,14 +150,6 @@
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel Rapid Storage Technology Driver">
-                  <CommandFile>..\software\aurora\Intel-Rapid-Storage-Technology-Driver_62C56_WIN64_17.9.6.1019_A04_01.exe</CommandFile>
-                  <CommandLine>cmd /c "intel-rapid-storage-technology-driver_62c56_win64_17.9.6.1019_a04_01.exe" /s /accepteula</CommandLine>
-                  <ContinueInstall>True</ContinueInstall>
-                  <RestartRequired>True</RestartRequired>
-                  <ReturnCodeRestart>3010</ReturnCodeRestart>
-                  <ReturnCodeSuccess>0</ReturnCodeSuccess>
-                </CommandConfig>
                 <CommandConfig Name="Intel WiFi Driver 22.170.0">
                   <CommandFile>..\software\intel\WiFi-22.170.0-Driver64-Win10-Win11.exe</CommandFile>
                   <CommandLine>cmd /c "wifi-22.170.0-driver64-win10-win11.exe" /s</CommandLine>

--- a/packages/clean_setup/clean_setup_customizations.xml
+++ b/packages/clean_setup/clean_setup_customizations.xml
@@ -3,7 +3,7 @@
   <PackageConfig xmlns="urn:schemas-Microsoft-com:Windows-ICD-Package-Config.v1.0">
     <ID>{3ce76392-6d3e-5a80-8a69-ed85ad8c84a4}</ID>
     <Name>Clean Setup</Name>
-    <Version>3.230</Version>
+    <Version>3.231</Version>
     <OwnerType>ITAdmin</OwnerType>
     <Rank>10</Rank>
     <Notes>Personal package for setting up PCs after a Windows clean installation. (10/28/2022)</Notes>
@@ -134,7 +134,7 @@
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel_Chipset_Driver">
+                <CommandConfig Name="Intel Chipset Driver">
                   <CommandFile>..\software\aurora\Intel-Chipset-Device-Software_5MPRF_WIN_10.1.18121.8164_A09.exe</CommandFile>
                   <CommandLine>cmd /c "intel-chipset-device-software_5mprf_win_10.1.18121.8164_A09.exe" /s</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
@@ -142,16 +142,16 @@
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel_Serial_IO_Driver">
-                  <CommandFile>..\software\aurora\Intel-Serial-IO-Driver_6CYP4_WIN_30.100.1943.2_A09_04.EXE</CommandFile>
+                <CommandConfig Name="Intel Serial IO Driver">
+                  <CommandFile>..\software\aurora\Intel-Serial-IO-Driver_6CYP4_WIN_30.100.1943.2_A09_04.exe</CommandFile>
                   <CommandLine>cmd /c "intel-serial-io-driver_6cyp4_win_30.100.1943.2_a09_04.exe" /s</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>True</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel_Rapid_Storage_Technology_Driver">
-                  <CommandFile>..\software\aurora\Intel-Rapid-Storage-Technology-Driver_62C56_WIN64_17.9.6.1019_A04_01.EXE</CommandFile>
+                <CommandConfig Name="Intel Rapid Storage Technology Driver">
+                  <CommandFile>..\software\aurora\Intel-Rapid-Storage-Technology-Driver_62C56_WIN64_17.9.6.1019_A04_01.exe</CommandFile>
                   <CommandLine>cmd /c "intel-rapid-storage-technology-driver_62c56_win64_17.9.6.1019_a04_01.exe" /s /accepteula</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>True</RestartRequired>
@@ -182,9 +182,9 @@
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Realtek_Audio_Driver">
-                  <CommandFile>..\software\aurora\Realtek-High-Definition-Audio-Driver_N9X47_WIN_6.0.8996.1_A03.exe</CommandFile>
-                  <CommandLine>cmd /c "realtek-high-definition-audio-driver_n9x47_win_6.0.8996.1_a03.exe" /s</CommandLine>
+                <CommandConfig Name="Realtek Audio Driver">
+                  <CommandFile>..\software\aurora\Realtek-High-Definition-Audio-Driver_X3H2T_WIN_6.0.9394.1_A01.exe</CommandFile>
+                  <CommandLine>cmd /c "realtek-high-definition-audio-driver_x3h2t_win_6.0.9394.1_a01.exe" /s</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>True</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>

--- a/packages/clean_setup/clean_setup_customizations.xml
+++ b/packages/clean_setup/clean_setup_customizations.xml
@@ -136,7 +136,7 @@
                 </CommandConfig>
                 <CommandConfig Name="Intel Chipset Driver">
                   <CommandFile>..\software\aurora\Intel-Chipset-Device-Software_5MPRF_WIN_10.1.18121.8164_A09.exe</CommandFile>
-                  <CommandLine>cmd /c "intel-chipset-device-software_5mprf_win_10.1.18121.8164_A09.exe" /s</CommandLine>
+                  <CommandLine>cmd /c "intel-chipset-device-software_5mprf_win_10.1.18121.8164_a09.exe" /s</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>True</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>

--- a/packages/clean_setup/clean_setup_customizations.xml
+++ b/packages/clean_setup/clean_setup_customizations.xml
@@ -159,7 +159,7 @@
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
                 <CommandConfig Name="Intel WiFi Driver 22.170.0">
-                  <CommandFile>..\software\intel\WiFi-22.170.0-Driver64-Win10-Win11</CommandFile>
+                  <CommandFile>..\software\intel\WiFi-22.170.0-Driver64-Win10-Win11.exe</CommandFile>
                   <CommandLine>cmd /c "wifi-22.170.0-driver64-win10-win11.exe" /s</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
@@ -244,7 +244,7 @@
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
                 <CommandConfig Name="Intel WiFi Driver 22.170.0">
-                  <CommandFile>..\software\intel\WiFi-22.170.0-Driver64-Win10-Win11</CommandFile>
+                  <CommandFile>..\software\intel\WiFi-22.170.0-Driver64-Win10-Win11.exe</CommandFile>
                   <CommandLine>cmd /c "wifi-22.170.0-driver64-win10-win11.exe" /s</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>

--- a/scripts/CreatePartitions-BIOS.txt
+++ b/scripts/CreatePartitions-BIOS.txt
@@ -7,25 +7,25 @@ rem == Clear all information on disk.
 select disk 0
 clean
 
-rem == System Partition ==
+rem == 1. System Partition ==
 create partition primary size=100
 format quick fs=ntfs label="System"
 assign letter=S
 active
 
-rem == Windows Partition ==
+rem == 2. Windows Partition ==
 rem == Create the Windows partition.
 create partition primary
 
-rem == Create space for the recovery tools ==
+rem == Create space for the recovery tools
 rem == Update this size to match the size of the recovery tools (winre.wim) plus some free space.
 shrink minimum=650
 
-rem == Windows Partition ==
+rem == Prepare Windows Partition
 format quick fs=ntfs label="Local Disk"
 assign letter=W
 
-rem == Recovery Partition ==
+rem == 3. Recovery Partition ==
 create partition primary size=650
 format quick fs=ntfs label="Recovery"
 assign letter=R

--- a/scripts/CreatePartitions-UEFI.txt
+++ b/scripts/CreatePartitions-UEFI.txt
@@ -8,29 +8,29 @@ select disk 0
 clean
 convert gpt
 
-rem == System Partition ==
+rem == 1. System Partition ==
 rem == For Advanced Format 4Kn drives, change this value to size=260.
 create partition efi size=260
 format quick fs=fat32 label="System"
 assign letter=S
 
-rem == Microsoft Reserved (MSR) Partition ==
+rem == 2. Microsoft Reserved (MSR) Partition ==
 create partition msr size=16
 
-rem == Windows Partition ==
+rem == 3. Windows Partition ==
 rem == Create the Windows partition.
 create partition primary
 
-rem == Create space for the recovery tools ==
+rem == Create space for the recovery tools
 rem == Update this size to match the size of the recovery tools (winre.wim) plus some free space.
 shrink minimum=910
 
-rem == Windows Partition ==
+rem == Prepare Windows Partition
 gpt attributes=0x0000000000000000
 format quick fs=ntfs label="Local Disk"
 assign letter=W
 
-rem == Recovery Partition ==
+rem == 4. Recovery Partition ==
 create partition primary size=910
 set id=DE94BBA4-06D1-4D40-A16A-BFD50179D6AC
 gpt attributes=0x8000000000000001


### PR DESCRIPTION
# Summary

Reevaluates and updates the drivers for the Dell Alienware Aurora R8.

- Remove underscores `_` from `CommandConfig` `Name` to main branch style.
- Correct capitalization for driver names and extensions.
- Remove Intel Rapid Storage Technology Driver as it is not needed. Alienware Aurora R8 is set to AHCI mode not RAID.
- Small comment and readability improvements to `CreatePartitions` scripts.

## Dell Driver Updates

| Driver | Version |
|:---|:---|
| Realtek Audio Driver | `X3H2T_WIN_6.0.9394.1_A01`|