### PR TITLE
Update Intel Drivers

### DIFF
--- a/packages/clean_setup/README.md
+++ b/packages/clean_setup/README.md
@@ -20,12 +20,27 @@ This package installs and updates a lot of core software including:
 ### Intel Drivers
 
 Installs the latest Intel drivers for supported processors and adapters.
-The included Intel drivers are for "modern" devices, but your device may require an older or a more advanced driver depending on your system for best performance.
+
+#### Intel Wireless (Wi-Fi & Bluetooth)
+
+The included Intel wireless drivers are for "modern" devices, but your device may require an older or a more advanced driver depending on your system for best performance.
 Check your specific system and the driver information on Intel's website for support details.
 
-* [Wi-Fi](https://www.intel.com/content/www/us/en/download/19351/)
-* [Bluetooth](https://www.intel.com/content/www/us/en/download/18649/)
-* [Graphics](https://www.intel.com/content/www/us/en/download/19344/)
+* [Intel Wireless Adapters (Wi-Fi)](https://www.intel.com/content/www/us/en/download/19351)
+* [Intel Wireless Bluetooth](https://www.intel.com/content/www/us/en/download/18649)
+
+#### Intel Graphics
+
+Intel separates their graphics drivers based on pre- and post-Xe architecture. 6th-10th Gen Processors have a shared driver, while Intel Arc and Iris Xe (11th-13th Gen) share a driver.
+This package specifically targets the Surface laptop 3 and Alienware Aurora R8, both of which have a 6th-10th Gen Processor.
+Therefore, on those two devices the Intel 6th-10th Gen Processor Graphics driver will be installed.
+
+* [Intel 6th-10th Gen Processor Graphics](https://www.intel.com/content/www/us/en/download/762755)
+* [Intel Arc & Iris Xe Graphics (11th-13th Gen)](https://www.intel.com/content/www/us/en/download/726609)
+
+> **Note**\
+> This package does not target any 11th-13th Gen Processor and therefore does not include the Intel Arc & Iris Xe Graphics driver.
+> It has been linked above for easy access if your device requires it.
 
 ### Surface Laptop 3
 

--- a/packages/clean_setup/clean_setup_customizations.xml
+++ b/packages/clean_setup/clean_setup_customizations.xml
@@ -174,9 +174,9 @@
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel Graphics Driver 31.0.101.2114-3790">
-                  <CommandFile>..\software\intel\gfx_win_101.3790_101.2114.exe</CommandFile>
-                  <CommandLine>cmd /c "gfx_win_101.3790_101.2114.exe" /s /report c:\Intel\31.0.101.2114-3790.Graphics.log</CommandLine>
+                <CommandConfig Name="Intel Graphics Driver 31.0.101.2115">
+                  <CommandFile>..\software\intel\gfx_win_101.2115.exe</CommandFile>
+                  <CommandLine>cmd /c "gfx_win_101.2115.exe" /s /report c:\Intel\31.0.101.2115.Graphics.log</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>True</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
@@ -259,9 +259,9 @@
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel Graphics Driver 31.0.101.2114-3790">
-                  <CommandFile>..\software\intel\gfx_win_101.3790_101.2114.exe</CommandFile>
-                  <CommandLine>cmd /c "gfx_win_101.3790_101.2114.exe" /s /report c:\Intel\31.0.101.2114-3790.Graphics.log</CommandLine>
+                <CommandConfig Name="Intel Graphics Driver 31.0.101.2115">
+                  <CommandFile>..\software\intel\gfx_win_101.2115.exe</CommandFile>
+                  <CommandLine>cmd /c "gfx_win_101.2115.exe" /s /report c:\Intel\31.0.101.2115.Graphics.log</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>True</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>

--- a/packages/clean_setup/clean_setup_customizations.xml
+++ b/packages/clean_setup/clean_setup_customizations.xml
@@ -158,17 +158,17 @@
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel WiFi Driver 22.190.0">
-                  <CommandFile>..\software\intel\WiFi-22.190.0-Driver64-Win10-Win11.exe</CommandFile>
-                  <CommandLine>cmd /c "wifi-22.190.0-driver64-win10-win11.exe" /s</CommandLine>
+                <CommandConfig Name="Intel WiFi Driver 22.200.2">
+                  <CommandFile>..\software\intel\WiFi-22.200.2-Driver64-Win10-Win11.exe</CommandFile>
+                  <CommandLine>cmd /c "wifi-22.200.2-driver64-win10-win11.exe" /s</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel Bluetooth Driver 22.190.0">
-                  <CommandFile>..\software\intel\BT-22.190.0-32-64UWD-Win10-Win11.exe</CommandFile>
-                  <CommandLine>cmd /c "bt-22.190.0-32-64uwd-win10-win11.exe" /qn</CommandLine>
+                <CommandConfig Name="Intel Bluetooth Driver 22.210.0">
+                  <CommandFile>..\software\intel\BT-22.210.0-64UWD-Win10-Win11.exe</CommandFile>
+                  <CommandLine>cmd /c "bt-22.210.0-64uwd-win10-win11.exe" /qn</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
@@ -243,17 +243,17 @@
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel WiFi Driver 22.190.0">
-                  <CommandFile>..\software\intel\WiFi-22.190.0-Driver64-Win10-Win11.exe</CommandFile>
-                  <CommandLine>cmd /c "wifi-22.190.0-driver64-win10-win11.exe" /s</CommandLine>
+                <CommandConfig Name="Intel WiFi Driver 22.200.2">
+                  <CommandFile>..\software\intel\WiFi-22.200.2-Driver64-Win10-Win11.exe</CommandFile>
+                  <CommandLine>cmd /c "wifi-22.200.2-driver64-win10-win11.exe" /s</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel Bluetooth Driver 22.190.0">
-                  <CommandFile>..\software\intel\BT-22.190.0-32-64UWD-Win10-Win11.exe</CommandFile>
-                  <CommandLine>cmd /c "bt-22.190.0-32-64uwd-win10-win11.exe" /qn</CommandLine>
+                <CommandConfig Name="Intel Bluetooth Driver 22.210.0">
+                  <CommandFile>..\software\intel\BT-22.210.0-64UWD-Win10-Win11.exe</CommandFile>
+                  <CommandLine>cmd /c "bt-22.210.0-64uwd-win10-win11.exe" /qn</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>


### PR DESCRIPTION
# Summary

Updates intel drivers for the Clean Setup package. Updates documentation regarding new Intel Graphics Drivers, see #57.

*Intel now separates graphics drivers for 6th-10th Gen Processors and 11th-13th Gen Processors.*

### References

- Resolves #57 

## Intel Driver Updates

| Driver | Version | Devices |
| :--- | :--- | :--- |
| Intel Wi-Fi | `22.200.2` | All |
| Intel Bluetooth | `22.210.0` | All |
| Intel Graphics | `31.0.101.2115` | Surface Laptop 3 & Alienware Aurora R8 |
