### PR TITLE
Remove Microsoft HEVC Video Extension

### DIFF
--- a/packages/clean_setup/clean_setup_customizations.xml
+++ b/packages/clean_setup/clean_setup_customizations.xml
@@ -3,7 +3,7 @@
   <PackageConfig xmlns="urn:schemas-Microsoft-com:Windows-ICD-Package-Config.v1.0">
     <ID>{3ce76392-6d3e-5a80-8a69-ed85ad8c84a4}</ID>
     <Name>Clean Setup</Name>
-    <Version>3.251</Version>
+    <Version>3.252</Version>
     <OwnerType>ITAdmin</OwnerType>
     <Rank>10</Rank>
     <Notes>Personal package for setting up PCs after a Windows clean installation. (03/25/2022)</Notes>
@@ -60,9 +60,6 @@
           <DeviceContextApp>
             <Application PackageFamilyName="Microsoft.AV1VideoExtension_8wekyb3d8bbwe">
               <ApplicationFile>..\software\core\Microsoft.AV1VideoExtension_1.1.52851.0_x64__8wekyb3d8bbwe.Appx</ApplicationFile>
-            </Application>
-            <Application PackageFamilyName="Microsoft.HEVCVideoExtension_8wekyb3d8bbwe">
-              <ApplicationFile>..\software\core\Microsoft.HEVCVideoExtension_2.0.60531.0_neutral___8wekyb3d8bbwe.AppxBundle</ApplicationFile>
             </Application>
           </DeviceContextApp>
         </UniversalAppInstall>

--- a/packages/terminal/terminal_customizations.xml
+++ b/packages/terminal/terminal_customizations.xml
@@ -3,7 +3,7 @@
   <PackageConfig xmlns="urn:schemas-Microsoft-com:Windows-ICD-Package-Config.v1.0">
     <ID>{39f22247-e434-5fb7-9598-a86bb76fb3aa}</ID>
     <Name>Terminal</Name>
-    <Version>3.250</Version>
+    <Version>3.252</Version>
     <OwnerType>ITAdmin</OwnerType>
     <Rank>30</Rank>
     <Notes>General package for installing Windows Terminal. (03/25/2022)</Notes>
@@ -36,9 +36,6 @@
           <DeviceContextApp>
             <Application PackageFamilyName="Microsoft.AV1VideoExtension_8wekyb3d8bbwe">
               <ApplicationFile>..\software\core\Microsoft.AV1VideoExtension_1.1.52851.0_x64__8wekyb3d8bbwe.Appx</ApplicationFile>
-            </Application>
-            <Application PackageFamilyName="Microsoft.HEVCVideoExtension_8wekyb3d8bbwe">
-              <ApplicationFile>..\software\core\Microsoft.HEVCVideoExtension_2.0.60531.0_neutral___8wekyb3d8bbwe.AppxBundle</ApplicationFile>
             </Application>
           </DeviceContextApp>
         </UniversalAppInstall>

--- a/packages/terminal_plus/terminal_plus_customizations.xml
+++ b/packages/terminal_plus/terminal_plus_customizations.xml
@@ -3,7 +3,7 @@
   <PackageConfig xmlns="urn:schemas-Microsoft-com:Windows-ICD-Package-Config.v1.0">
     <ID>{69f54890-b0fc-57db-b44e-627df747a906}</ID>
     <Name>Terminal+</Name>
-    <Version>3.250</Version>
+    <Version>3.252</Version>
     <OwnerType>ITAdmin</OwnerType>
     <Rank>20</Rank>
     <Notes>General package for installing Windows Terminal and other common software. (03/25/2022)</Notes>
@@ -60,9 +60,6 @@
           <DeviceContextApp>
             <Application PackageFamilyName="Microsoft.AV1VideoExtension_8wekyb3d8bbwe">
               <ApplicationFile>..\software\core\Microsoft.AV1VideoExtension_1.1.52851.0_x64__8wekyb3d8bbwe.Appx</ApplicationFile>
-            </Application>
-            <Application PackageFamilyName="Microsoft.HEVCVideoExtension_8wekyb3d8bbwe">
-              <ApplicationFile>..\software\core\Microsoft.HEVCVideoExtension_2.0.60531.0_neutral___8wekyb3d8bbwe.AppxBundle</ApplicationFile>
             </Application>
           </DeviceContextApp>
         </UniversalAppInstall>

--- a/packages/vm_core/vm_core_customizations.xml
+++ b/packages/vm_core/vm_core_customizations.xml
@@ -3,7 +3,7 @@
   <PackageConfig xmlns="urn:schemas-Microsoft-com:Windows-ICD-Package-Config.v1.0">
     <ID>{26e7fa9d-bbe4-5055-8e92-8d45e934bcfb}</ID>
     <Name>Virtual Machine Core</Name>
-    <Version>3.250</Version>
+    <Version>3.252</Version>
     <OwnerType>ITAdmin</OwnerType>
     <Rank>40</Rank>
     <Notes>Made specifically for Virtual Machines. (03/25/2023)</Notes>
@@ -60,9 +60,6 @@
           <DeviceContextApp>
             <Application PackageFamilyName="Microsoft.AV1VideoExtension_8wekyb3d8bbwe">
               <ApplicationFile>..\software\core\Microsoft.AV1VideoExtension_1.1.52851.0_x64__8wekyb3d8bbwe.Appx</ApplicationFile>
-            </Application>
-            <Application PackageFamilyName="Microsoft.HEVCVideoExtension_8wekyb3d8bbwe">
-              <ApplicationFile>..\software\core\Microsoft.HEVCVideoExtension_2.0.60531.0_neutral___8wekyb3d8bbwe.AppxBundle</ApplicationFile>
             </Application>
           </DeviceContextApp>
         </UniversalAppInstall>


### PR DESCRIPTION
# Summary

As outlined in #62, the `Microsoft.HEVCVideoExtension` is now included by default in Windows 11 22H2 and later. Therefore we can remove it from all provisioning packages. Microsoft may include an older version than we provision, but it will be automatically updated after OOBE through Microsoft Store. That is better as it will work for all architecture types and keeps this repository cleaner.

## References

* Resolves #62 

## Updates

| Name | Version | Type |
| :--- | :--- | :--- |
| HEVCVideoExtension | `Removed` | Extension |