### PR TITLE
Update Intel Drivers

### DIFF
--- a/packages/clean_setup/README.md
+++ b/packages/clean_setup/README.md
@@ -31,11 +31,12 @@ Check your specific system and the driver information on Intel's website for sup
 
 #### Intel Graphics
 
-Intel separates their graphics drivers based on pre- and post-Xe architecture. 6th-10th Gen Processors have a shared driver, while Intel Arc and Iris Xe (11th-13th Gen) share a driver.
-This package specifically targets the Surface laptop 3 and Alienware Aurora R8, both of which have a 6th-10th Gen Processor.
-Therefore, on those two devices the Intel 6th-10th Gen Processor Graphics driver will be installed.
+Intel separates their graphics drivers based on pre- and post-Xe architecture.
+7th-10th Gen Processors have a shared driver, while Intel Arc and Iris Xe (11th-13th Gen) share a driver.
+This package specifically targets the Surface laptop 3 and Alienware Aurora R8, both of which have a 7th-10th Gen Processor.
+Therefore, on those two devices the Intel 7th-10th Gen Processor Graphics driver will be installed.
 
-* [Intel 6th-10th Gen Processor Graphics](https://www.intel.com/content/www/us/en/download/762755)
+* [Intel 7th-10th Gen Processor Graphics](https://www.intel.com/content/www/us/en/download/776137)
 * [Intel Arc & Iris Xe Graphics (11th-13th Gen)](https://www.intel.com/content/www/us/en/download/726609)
 
 > **Note**\

--- a/packages/clean_setup/clean_setup_customizations.xml
+++ b/packages/clean_setup/clean_setup_customizations.xml
@@ -3,10 +3,10 @@
   <PackageConfig xmlns="urn:schemas-Microsoft-com:Windows-ICD-Package-Config.v1.0">
     <ID>{3ce76392-6d3e-5a80-8a69-ed85ad8c84a4}</ID>
     <Name>Clean Setup</Name>
-    <Version>3.252</Version>
+    <Version>3.261</Version>
     <OwnerType>ITAdmin</OwnerType>
     <Rank>10</Rank>
-    <Notes>Personal package for setting up PCs after a Windows clean installation. (03/25/2022)</Notes>
+    <Notes>Personal package for setting up PCs after a Windows clean installation. (07/11/2023)</Notes>
   </PackageConfig>
   <Settings xmlns="urn:schemas-microsoft-com:windows-provisioning">
     <Customizations>
@@ -147,25 +147,25 @@
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel WiFi Driver 22.200.2">
-                  <CommandFile>..\software\intel\WiFi-22.200.2-Driver64-Win10-Win11.exe</CommandFile>
-                  <CommandLine>cmd /c "wifi-22.200.2-driver64-win10-win11.exe" /s</CommandLine>
+                <CommandConfig Name="Intel WiFi Driver 22.230.0">
+                  <CommandFile>..\software\intel\WiFi-22.230.0-Driver64-Win10-Win11.exe</CommandFile>
+                  <CommandLine>cmd /c "wifi-22.230.0-driver64-win10-win11.exe" /s</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel Bluetooth Driver 22.210.0">
-                  <CommandFile>..\software\intel\BT-22.210.0-64UWD-Win10-Win11.exe</CommandFile>
-                  <CommandLine>cmd /c "bt-22.210.0-64uwd-win10-win11.exe" /qn</CommandLine>
+                <CommandConfig Name="Intel Bluetooth Driver 22.230.0">
+                  <CommandFile>..\software\intel\BT-22.230.0-64UWD-Win10-Win11.exe</CommandFile>
+                  <CommandLine>cmd /c "bt-22.230.0-64uwd-win10-win11.exe" /qn</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel Graphics Driver 31.0.101.2115">
-                  <CommandFile>..\software\intel\gfx_win_101.2115.exe</CommandFile>
-                  <CommandLine>cmd /c "gfx_win_101.2115.exe" /s /report c:\Intel\31.0.101.2115.Graphics.log</CommandLine>
+                <CommandConfig Name="Intel Graphics Driver 31.0.101.2125">
+                  <CommandFile>..\software\intel\gfx_win_101.2125.exe</CommandFile>
+                  <CommandLine>cmd /c "gfx_win_101.2125.exe" /s /report c:\Intel\31.0.101.2125.Graphics.log</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>True</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
@@ -232,25 +232,25 @@
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel WiFi Driver 22.200.2">
-                  <CommandFile>..\software\intel\WiFi-22.200.2-Driver64-Win10-Win11.exe</CommandFile>
-                  <CommandLine>cmd /c "wifi-22.200.2-driver64-win10-win11.exe" /s</CommandLine>
+                <CommandConfig Name="Intel WiFi Driver 22.230.0">
+                  <CommandFile>..\software\intel\WiFi-22.230.0-Driver64-Win10-Win11.exe</CommandFile>
+                  <CommandLine>cmd /c "wifi-22.230.0-driver64-win10-win11.exe" /s</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel Bluetooth Driver 22.210.0">
-                  <CommandFile>..\software\intel\BT-22.210.0-64UWD-Win10-Win11.exe</CommandFile>
-                  <CommandLine>cmd /c "bt-22.210.0-64uwd-win10-win11.exe" /qn</CommandLine>
+                <CommandConfig Name="Intel Bluetooth Driver 22.230.0">
+                  <CommandFile>..\software\intel\BT-22.230.0-64UWD-Win10-Win11.exe</CommandFile>
+                  <CommandLine>cmd /c "bt-22.230.0-64uwd-win10-win11.exe" /qn</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>False</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>
                   <ReturnCodeSuccess>0</ReturnCodeSuccess>
                 </CommandConfig>
-                <CommandConfig Name="Intel Graphics Driver 31.0.101.2115">
-                  <CommandFile>..\software\intel\gfx_win_101.2115.exe</CommandFile>
-                  <CommandLine>cmd /c "gfx_win_101.2115.exe" /s /report c:\Intel\31.0.101.2115.Graphics.log</CommandLine>
+                <CommandConfig Name="Intel Graphics Driver 31.0.101.2125">
+                  <CommandFile>..\software\intel\gfx_win_101.2125.exe</CommandFile>
+                  <CommandLine>cmd /c "gfx_win_101.2125.exe" /s /report c:\Intel\31.0.101.2125.Graphics.log</CommandLine>
                   <ContinueInstall>True</ContinueInstall>
                   <RestartRequired>True</RestartRequired>
                   <ReturnCodeRestart>3010</ReturnCodeRestart>


### PR DESCRIPTION
# Summary

Updates Intel drivers for the Clean Setup package. Updates documentation, replaces 6th-10th gen driver with 7th-10th gen driver. It seems like Intel has discontinued 6th gen driver updates.

*Intel now separates graphics drivers for 6th-10th Gen Processors and 11th-13th Gen Processors.* #57 

## Intel Driver Updates

| Driver | Version | Devices |
| :--- | :--- | :--- |
| Intel Wi-Fi | `22.230.0` | All |
| Intel Bluetooth | `22.230.0` | All |
| Intel Graphics | `31.0.101.2125` | Surface Laptop 3 & Alienware Aurora R8 |