### PR TITLE
Remove HEVC Video Extension from package documentation

### DIFF
--- a/packages/clean_setup/README.md
+++ b/packages/clean_setup/README.md
@@ -15,7 +15,6 @@ This package installs and updates a lot of core software including:
 * OneDrive
 * Google Chrome
 * Microsoft AV1 Video Extension
-* Microsoft HEVC Video Extension
 
 ### Intel Drivers
 

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -9,4 +9,3 @@ This package will install and update the following software:
 
 * PowerShell
 * Microsoft AV1 Video Extension
-* Microsoft HEVC Video Extension

--- a/packages/terminal_plus/README.md
+++ b/packages/terminal_plus/README.md
@@ -12,4 +12,3 @@ This package will install and update the following software:
 * OneDrive
 * Google Chrome
 * Microsoft AV1 Video Extension
-* Microsoft HEVC Video Extension

--- a/packages/vm_core/README.md
+++ b/packages/vm_core/README.md
@@ -13,7 +13,6 @@ This package will install and update the following software:
 * OneDrive
 * Google Chrome
 * Microsoft AV1 Video Extension
-* Microsoft HEVC Video Extension
 
 ## Removed Software
 


### PR DESCRIPTION
# Summary

Unfortunately, as outlined in #67, pull request #63 failed to remove the HEVC Video Extension from package documentation. This pull request remedies that oversight.

## References

* Fixes #67