### PR TITLE
Update Surface Laptop 3 drivers list and MSI documentation

### DIFF
--- a/docs/msi.md
+++ b/docs/msi.md
@@ -19,11 +19,11 @@ The second example explicitly uses the installer's absolute path so the shell's 
 *I like to put quotes around `<installer.msi>`, but they aren't necessary.*
 
 ```PowerShell
-msiexec /a "SurfaceLaptop3_Win11_22000_23.034.44302.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
+msiexec /a "SurfaceLaptop3_Win11_22000_23.062.21635.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
 ```
 
 ```PowerShell
-msiexec /a "C:\provisioning\software\surface\SurfaceLaptop3_Win11_22000_23.034.44302.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
+msiexec /a "C:\provisioning\software\surface\SurfaceLaptop3_Win11_22000_23.062.21635.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
 ```
 
 | Option            | Meaning                                                                                                                    |

--- a/docs/msi.md
+++ b/docs/msi.md
@@ -8,20 +8,27 @@ The Microsoft Windows Installer service enables better corporate deployment and 
 The **TARGETDIR** property specifies the root destination directory for the installation.
 For more information, see [TARGETDIR property](https://docs.microsoft.com/windows/win32/msi/targetdir).
 
-> **Note**\
-> The `TARGETDIR` parameter must be given an absolute path, and the path must exist.
-> It will not create directories for you.
+This should not install the product, but instead simply unpack it into the target directory.
+*[I use this for comparing driver changes in Microsoft Surface driver packages without having to actually install them.](surface-laptop-3)*
 
-```shell
-msiexec /a "SurfaceLaptop3_Win11_22000_22.081.11638.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
+> **Warning**\
+> The `<installer.msi>` and `TARGETDIR=` parameters must be absolute paths.
+
+In the first example, the installer is in my shell's current working directory, so it still executes fine.
+The second example explicitly uses the installer's absolute path so the shell's working directory can be anywhere.
+*I like to put quotes around `<installer.msi>`, but they aren't necessary.*
+
+```PowerShell
+msiexec /a "SurfaceLaptop3_Win11_22000_23.021.14365.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
 ```
 
-| Option          | Meaning                                                                                                                    |
-|:----------------|:---------------------------------------------------------------------------------------------------------------------------|
-| `/a`            | [Administrative Installation](https://docs.microsoft.com/windows/win32/msi/administrative-installation)                    |
-| `<product.msi>` | Product to install.                                                                                                        |
-| `/passive`      | [Only shows a progress bar.](https://docs.microsoft.com/windows/win32/msi/standard-installer-command-line-options#passive) |
-| `TARGETDIR`     | [Unpacks the installer into the specified location.](https://docs.microsoft.com/windows/win32/msi/targetdir)               |
+```PowerShell
+msiexec /a "C:\provisioning\software\surface\SurfaceLaptop3_Win11_22000_23.021.14365.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
+```
 
-This should not actually install the product, but instead simply unpack it into the specified directory.
-I use this for comparing driver changes in Microsoft Surface driver packages without having to actually install them.
+| Option            | Meaning                                                                                                                    |
+|:------------------|:---------------------------------------------------------------------------------------------------------------------------|
+| `/a`              | [Administrative Installation](https://docs.microsoft.com/windows/win32/msi/administrative-installation)                    |
+| `<installer.msi>` | Microsoft Windows Installer package to install.                                                                            |
+| `/passive`        | [Only shows a progress bar.](https://docs.microsoft.com/windows/win32/msi/standard-installer-command-line-options#passive) |
+| `TARGETDIR=`      | [Unpacks the installer into the specified location.](https://docs.microsoft.com/windows/win32/msi/targetdir)               |

--- a/docs/msi.md
+++ b/docs/msi.md
@@ -19,11 +19,11 @@ The second example explicitly uses the installer's absolute path so the shell's 
 *I like to put quotes around `<installer.msi>`, but they aren't necessary.*
 
 ```PowerShell
-msiexec /a "SurfaceLaptop3_Win11_22000_23.021.14365.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
+msiexec /a "SurfaceLaptop3_Win11_22000_23.034.44302.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
 ```
 
 ```PowerShell
-msiexec /a "C:\provisioning\software\surface\SurfaceLaptop3_Win11_22000_23.021.14365.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
+msiexec /a "C:\provisioning\software\surface\SurfaceLaptop3_Win11_22000_23.034.44302.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
 ```
 
 | Option            | Meaning                                                                                                                    |

--- a/docs/surface-laptop-3/README.md
+++ b/docs/surface-laptop-3/README.md
@@ -10,8 +10,8 @@ I keep track of this because I have a Surface Laptop 3, and it's nice to know wh
 ## Data
 
 **Device:** [Surface Laptop 3 with Intel Processor](https://www.microsoft.com/download/details.aspx?id=100429)\
-**File Name:** `SurfaceLaptop3_Win11_22000_23.034.44302.0.msi`\
-**Date Published:** 5/16/2023\
+**File Name:** `SurfaceLaptop3_Win11_22000_23.062.21635.0.msi`\
+**Date Published:** 7/13/2023\
 **OS:** Windows 11 22000\
-**Driver:** 23.034.44302.0\
+**Driver:** 23.062.21635.0\
 **List:** [SurfaceLaptop3Drivers](SurfaceLaptop3Drivers.txt)

--- a/docs/surface-laptop-3/README.md
+++ b/docs/surface-laptop-3/README.md
@@ -10,8 +10,8 @@ I keep track of this because I have a Surface Laptop 3, and it's nice to know wh
 ## Data
 
 **Device:** [Surface Laptop 3 with Intel Processor](https://www.microsoft.com/download/details.aspx?id=100429)\
-**File Name:** `SurfaceLaptop3_Win11_22000_23.021.14365.0.msi`\
-**Date Published:** 3/31/2023\
+**File Name:** `SurfaceLaptop3_Win11_22000_23.034.44302.0.msi`\
+**Date Published:** 5/16/2023\
 **OS:** Windows 11 22000\
-**Driver:** 23.021.14365.0\
+**Driver:** 23.034.44302.0\
 **List:** [SurfaceLaptop3Drivers](SurfaceLaptop3Drivers.txt)

--- a/docs/surface-laptop-3/README.md
+++ b/docs/surface-laptop-3/README.md
@@ -10,8 +10,8 @@ I keep track of this because I have a Surface Laptop 3, and it's nice to know wh
 ## Data
 
 **Device:** [Surface Laptop 3 with Intel Processor](https://www.microsoft.com/download/details.aspx?id=100429)\
-**File Name:** `SurfaceLaptop3_Win11_22000_22.081.11638.0.msi`\
-**Date Published:** 8/25/2022\
+**File Name:** `SurfaceLaptop3_Win11_22000_23.021.14365.0.msi`\
+**Date Published:** 3/31/2023\
 **OS:** Windows 11 22000\
-**Driver:** 22.081.11638.0\
+**Driver:** 23.021.14365.0\
 **List:** [SurfaceLaptop3Drivers](SurfaceLaptop3Drivers.txt)

--- a/docs/surface-laptop-3/SurfaceLaptop3Drivers.txt
+++ b/docs/surface-laptop-3/SurfaceLaptop3Drivers.txt
@@ -8,8 +8,8 @@ Device(s): Surface Laptop 3
 List of Included Firmware and Drivers
 ====================================================================================================================
 
-Class              InfName                                 Version         Date
------              -------                                 -------         ----
+Class              InfName                                 Version         Date      
+-----              -------                                 -------         ----      
 Battery            SurfaceBattery.inf                      1.60.139.0      08/22/2019
 Bluetooth          ibtusb.inf                              22.40.0.2       09/26/2021
 CTA Driver Devices MiniCtaDriver.inf                       27.20.100.9621  06/15/2021
@@ -17,8 +17,9 @@ Display            iigd_dch.inf                            27.20.100.9621  06/15
 Display            iigd_dch_d.inf                          27.20.100.9621  06/15/2021
 Extension          HdBusExt.inf                            27.20.100.9621  06/15/2021
 Extension          iigd_ext_Av.inf                         27.20.100.9621  06/16/2021
+Extension          IntcOED_OemLibPathExt.inf               10.24.245.1     01/19/2023
 Extension          OemExtension.inf                        1952.14.0.1470  12/25/2019
-Extension          RealtekExt.inf                          6.1.0.6         03/25/2020
+Extension          RealtekExt.inf                          6.1.0.16        08/17/2021
 Extension          SurfaceDigitizerVirtualFunctionEnum.inf 1.13.139.0      08/05/2019
 Extension          SurfaceDock2FwUpdate.inf                6.8.137.0       08/26/2021
 Extension          SurfaceHIDFriendlyNames.inf             1.8.137.0       08/10/2019
@@ -44,18 +45,15 @@ HIDClass           SurfaceHidMiniDriver.inf                3.31.139.0      10/16
 HIDClass           SurfacePen217Integration.inf            1.5.139.0       08/02/2019
 HIDClass           SurfaceTconDriver.inf                   3.50.139.0      08/22/2019
 HIDClass           SurfaceVirtualFunctionEnum.inf          1.18.139.0      08/10/2019
-MEDIA              HDXACPM.inf                             6.0.8936.1      04/13/2020
-MEDIA              HDXHAPM.inf                             6.0.8936.1      04/13/2020
-MEDIA              HDXHAPMRTKWOV.inf                       6.0.8936.1      04/13/2020
-MEDIA              HDXSSTM.inf                             6.0.8936.1      04/13/2020
-MEDIA              HDXSSTM2.inf                            6.0.8936.1      04/13/2020
-MEDIA              HDXSSTMCO.inf                           6.0.8936.1      04/13/2020
-MEDIA              HDXSSTMD3A.inf                          6.0.8936.1      04/13/2020
-MEDIA              HDXSSTMND.inf                           6.0.8936.1      04/13/2020
+MEDIA              HDXSSTM2.inf                            6.0.9249.2      10/08/2021
+MEDIA              IntcBTAu.inf                            10.24.0.7927    08/02/2022
 MEDIA              IntcDAud.inf                            10.26.0.10      04/16/2021
 MEDIA              IntcDAud.inf                            10.27.0.10      04/16/2021
 MEDIA              IntcDAud.inf                            11.1.0.18       04/16/2021
 MEDIA              IntcDAud.inf                            11.2.0.8        04/16/2021
+MEDIA              IntcDMic.inf                            10.24.0.7927    08/02/2022
+MEDIA              IntcSDW.inf                             10.24.0.7927    08/02/2022
+MEDIA              IntcSST.inf                             10.24.0.7927    08/02/2022
 MEDIA              MSHdaDac.inf                            27.20.100.9621  06/15/2021
 Monitor            SurfaceOemPanel.inf                     6.81.139.0      07/15/2021
 net                Netwtw08.INF                            22.40.0.7       09/19/2021
@@ -63,7 +61,8 @@ SoftwareComponent  cui_dch.inf                             27.20.100.9621  06/15
 SoftwareComponent  iclsClient.inf                          1.63.1155.2     12/01/2021
 SoftwareComponent  igcc_dch.inf                            27.20.100.9621  06/15/2021
 SoftwareComponent  RealtekHSA.inf                          11.0.6000.92    05/29/2018
-System             DetectionVerificationDrv.inf            1.0.1069.0      06/13/2019
+System             DetectionVerificationDrv.inf            1.0.2283.0      05/17/2022
+System             DetectionVerificationDrv.inf            1.0.2283.0      05/17/2022
 System             dptf_acpi.inf                           8.6.10401.9906  06/14/2019
 System             dptf_cpu.inf                            8.6.10401.9906  06/14/2019
 System             GSCAuxDriver.inf                        2110.0.9.0      03/03/2021
@@ -76,8 +75,9 @@ System             iaLPSS2_UART2_ICL.inf                   30.100.1932.6   08/08
 System             IceLakePCH-LPSystem.inf                 10.1.12.2       07/18/1968
 System             IceLakePCH-LPSystemLPSS.inf             10.1.12.2       07/18/1968
 System             IceLakePCH-LPSystemNorthpeak.inf        10.1.12.2       07/18/1968
-System             IntcAudioBus.inf                        10.24.0.3694    03/13/2020
-System             IntcOED.inf                             10.24.0.3694    03/13/2020
+System             IntcAudioBus.inf                        10.24.0.7927    08/02/2022
+System             IntcOED.inf                             10.24.0.7927    08/02/2022
+System             IntcOED.inf                             10.24.0.7927    08/02/2022
 System             memcntrl.inf                            27.20.100.9621  06/15/2021
 System             SurfaceAcpiNotifyDriver.inf             7.52.139.0      08/22/2019
 System             SurfaceButton.inf                       3.43.139.0      08/22/2019
@@ -88,5 +88,7 @@ System             SurfacePen217FwUpdate.inf               1.7.139.0       08/02
 System             SurfacePenPairing.inf                   4.13.139.0      08/02/2019
 System             SurfacePowerTrackerCore.inf             1.44.139.0      08/22/2019
 System             SurfaceSerialHubDriver.inf              9.54.139.0      01/22/2021
-System             SurfaceServiceNullDriver.inf            6.119.139.0     03/17/2021
+System             SurfaceServiceNullDriver.inf            6.201.139.0     09/12/2022
 UCM                SurfaceUcmUcsiHidClient.inf             1.19.139.0      07/28/2019
+
+

--- a/docs/surface-laptop-3/SurfaceLaptop3Drivers.txt
+++ b/docs/surface-laptop-3/SurfaceLaptop3Drivers.txt
@@ -40,7 +40,7 @@ Firmware           SurfaceThunderbolt4DockFwUpdate.inf     2.26.4.0        03/03
 Firmware           SurfaceTouchFw.inf                      3.0.213.139     08/21/2019
 Firmware           SurfaceTouchFw.inf                      3.0.213.139     08/21/2019
 Firmware           SurfaceTPM.inf                          7.2.2.0         12/03/2020
-Firmware           SurfaceUEFI.inf                         15.11.140.0     07/08/2022
+Firmware           SurfaceUEFI.inf                         16.102.140.0    04/06/2023
 HIDClass           iaPreciseTouch.inf                      2.1.0.59        07/30/2019
 HIDClass           SurfaceDockIntegration.inf              1.24.139.0      07/24/2019
 HIDClass           SurfaceHidMiniDriver.inf                3.31.139.0      10/16/2020
@@ -58,6 +58,8 @@ MEDIA              IntcSDW.inf                             10.24.0.7927    08/02
 MEDIA              IntcSST.inf                             10.24.0.7927    08/02/2022
 MEDIA              MSHdaDac.inf                            27.20.100.9621  06/15/2021
 Monitor            SurfaceOemPanel.inf                     6.81.139.0      07/15/2021
+Net                msu53cx22x64sta.INF                     1153.9.20.823   08/23/2022
+Net                msu56cx22x64sta.INF                     1156.9.20.823   08/23/2022
 net                Netwtw08.INF                            22.190.0.4      11/23/2022
 SoftwareComponent  cui_dch.inf                             27.20.100.9621  06/15/2021
 SoftwareComponent  iclsClient.inf                          1.63.1155.2     12/01/2021

--- a/docs/surface-laptop-3/SurfaceLaptop3Drivers.txt
+++ b/docs/surface-laptop-3/SurfaceLaptop3Drivers.txt
@@ -11,17 +11,18 @@ List of Included Firmware and Drivers
 Class              InfName                                 Version         Date      
 -----              -------                                 -------         ----      
 Battery            SurfaceBattery.inf                      1.60.139.0      08/22/2019
-Bluetooth          ibtusb.inf                              22.40.0.2       09/26/2021
+Bluetooth          ibtusb.inf                              22.190.0.2      11/08/2022
 CTA Driver Devices MiniCtaDriver.inf                       27.20.100.9621  06/15/2021
 Display            iigd_dch.inf                            27.20.100.9621  06/15/2021
 Display            iigd_dch_d.inf                          27.20.100.9621  06/15/2021
+Extension          DevicesTelemetryServiceDriver.inf       6.196.139.0     02/16/2023
 Extension          HdBusExt.inf                            27.20.100.9621  06/15/2021
 Extension          iigd_ext_Av.inf                         27.20.100.9621  06/16/2021
 Extension          IntcOED_OemLibPathExt.inf               10.24.245.1     01/19/2023
 Extension          OemExtension.inf                        1952.14.0.1470  12/25/2019
 Extension          RealtekExt.inf                          6.1.0.16        08/17/2021
 Extension          SurfaceDigitizerVirtualFunctionEnum.inf 1.13.139.0      08/05/2019
-Extension          SurfaceDock2FwUpdate.inf                6.8.137.0       08/26/2021
+Extension          SurfaceDock2FwUpdate.inf                6.13.137.0      11/22/2022
 Extension          SurfaceHIDFriendlyNames.inf             1.8.137.0       08/10/2019
 Extension          SurfacePowerFilter.inf                  1.39.139.0      08/22/2019
 Extension          SurfaceTouchPenProcessorUpdate.inf      3.208.137.0     02/22/2021
@@ -35,6 +36,7 @@ Firmware           SurfaceSAM.inf                          14.602.139.0    05/09
 Firmware           SurfaceStorageFwUpdate.inf              5.34.139.0      07/28/2019
 Firmware           SurfaceTCON.inf                         160.35.13.0     06/13/2019
 Firmware           SurfaceTCON.inf                         160.35.15.0     06/13/2019
+Firmware           SurfaceThunderbolt4DockFwUpdate.inf     2.26.4.0        03/03/2023
 Firmware           SurfaceTouchFw.inf                      3.0.213.139     08/21/2019
 Firmware           SurfaceTouchFw.inf                      3.0.213.139     08/21/2019
 Firmware           SurfaceTPM.inf                          7.2.2.0         12/03/2020
@@ -56,7 +58,7 @@ MEDIA              IntcSDW.inf                             10.24.0.7927    08/02
 MEDIA              IntcSST.inf                             10.24.0.7927    08/02/2022
 MEDIA              MSHdaDac.inf                            27.20.100.9621  06/15/2021
 Monitor            SurfaceOemPanel.inf                     6.81.139.0      07/15/2021
-net                Netwtw08.INF                            22.40.0.7       09/19/2021
+net                Netwtw08.INF                            22.190.0.4      11/23/2022
 SoftwareComponent  cui_dch.inf                             27.20.100.9621  06/15/2021
 SoftwareComponent  iclsClient.inf                          1.63.1155.2     12/01/2021
 SoftwareComponent  igcc_dch.inf                            27.20.100.9621  06/15/2021
@@ -88,7 +90,7 @@ System             SurfacePen217FwUpdate.inf               1.7.139.0       08/02
 System             SurfacePenPairing.inf                   4.13.139.0      08/02/2019
 System             SurfacePowerTrackerCore.inf             1.44.139.0      08/22/2019
 System             SurfaceSerialHubDriver.inf              9.54.139.0      01/22/2021
-System             SurfaceServiceNullDriver.inf            6.201.139.0     09/12/2022
+System             SurfaceServiceNullDriver.inf            6.204.139.0     10/30/2022
 UCM                SurfaceUcmUcsiHidClient.inf             1.19.139.0      07/28/2019
 
 


### PR DESCRIPTION
# Summary

- Improved the MSI command documentation.
- Updated Surface Laptop 3 with Intel Processor drivers list to `23.062.21635.0`.

## Updates

| Name | OS | Version | Type |
| :--- | :--- | :--- | :--- |
| Surface Laptop 3 with Intel Processor | Windows 11 `22000` |  `23.062.21635.0` | Drivers and Firmware |
