### PR TITLE
Update Microsoft Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository acts as a living space for the continuation and maintenance of t
 > **Note**\
 > Please have a basic understanding of Windows provisioning before opening an issue, but do not be afraid to ask for help. Thanks!
 >
-> For more information, see [Provisioning packages for Windows](https://docs.microsoft.com/windows/configuration/provisioning-packages/provisioning-packages).
+> For more information, see [Provisioning packages for Windows](https://learn.microsoft.com/windows/configuration/provisioning-packages/provisioning-packages).
 
 ## Documentation
 
@@ -53,8 +53,8 @@ Each directory has a readme to explain its purpose in more detail.
 
 ### Prerequisites
 
-- Install the [Windows Imaging and Configuration Designer (ICD)](https://www.microsoft.com/store/apps/9nblggh4tx22).
-- Read the [ICD command-line interface reference](https://docs.microsoft.com/windows/configuration/provisioning-packages/provisioning-command-line).
+- Install the [Windows Imaging and Configuration Designer (ICD)](https://www.microsoft.com/store/productId/9NBLGGH4TX22).
+- Read the [ICD command-line interface reference](https://learn.microsoft.com/windows/configuration/provisioning-packages/provisioning-command-line).
 
 ### Building Packages
 
@@ -63,7 +63,7 @@ See [Building Provisioning Packages](packages/building.md).
 ### Installing Packages
 
 Execute or double-click the `ppkg` file on a Windows device.
-For more information, see [Apply a provisioning package](https://docs.microsoft.com/windows/configuration/provisioning-packages/provisioning-apply-package).
+For more information, see [Apply a provisioning package](https://learn.microsoft.com/windows/configuration/provisioning-packages/provisioning-apply-package).
 
 ## Contribution
 

--- a/docs/appx.md
+++ b/docs/appx.md
@@ -1,12 +1,12 @@
 # AppX Cmdlets
 
-A curated list of [AppX](https://docs.microsoft.com/powershell/module/appx/) cmdlets.
+A curated list of [AppX](https://learn.microsoft.com/powershell/module/appx/) cmdlets.
 The Windows PowerShell cmdlets for AppX are designed to streamline the administration of MSIX or AppX package management.
 
 ## Get-AppxPackage
 
 The **Get-AppxPackage** cmdlet gets a list of the app packages that are installed in a user profile.
-For more information, see [Get-AppxPackage](https://docs.microsoft.com/powershell/module/appx/get-appxpackage).
+For more information, see [Get-AppxPackage](https://learn.microsoft.com/powershell/module/appx/get-appxpackage).
 
 ```shell
 Get-AppxPackage
@@ -23,7 +23,7 @@ Get-AppxPackage -AllUsers -Name "Microsoft.WindowsTerminal"
 ## Remove-AppxPackage
 
 The **Remove-AppxPackage** cmdlet removes an app package from a user account.
-For more information, see [Remove-AppxPackage](https://docs.microsoft.com/powershell/module/appx/remove-appxpackage).
+For more information, see [Remove-AppxPackage](https://learn.microsoft.com/powershell/module/appx/remove-appxpackage).
 
 ```shell
 Remove-AppxPackage
@@ -38,7 +38,7 @@ The parameters: `-AllUsers`, `-Confirm`, and `-WhatIf` might also be helpful.
 ## Reset-AppxPackage
 
 The **Reset-AppxPackage** cmdlet will reset the app to its original settings, and the app will react as a freshly installed app.
-For more information, see [Reset-AppxPackage](https://docs.microsoft.com/powershell/module/appx/reset-appxpackage).
+For more information, see [Reset-AppxPackage](https://learn.microsoft.com/powershell/module/appx/reset-appxpackage).
 
 ```shell
 Reset-AppxPackage -Package "Microsoft.WindowsCalculator_11.2207.11.0_x64__8wekyb3d8bbwe"

--- a/docs/dism.md
+++ b/docs/dism.md
@@ -1,12 +1,12 @@
 # Deployment Image Servicing and Management (DISM) Cmdlets
 
-A curated list of [Deployment Image Servicing and Management](https://docs.microsoft.com/powershell/module/dism/) cmdlets.
+A curated list of [Deployment Image Servicing and Management](https://learn.microsoft.com/powershell/module/dism/) cmdlets.
 The Deployment Image Servicing and Management platform is used to mount and service Windows images.
 
 ## Clear-WindowsCorruptMountPoint
 
 The **Clear-WindowsCorruptMountPoint** cmdlet deletes all of the resources associated with a mounted image that has been corrupted.
-For more information, see [Clear-WindowsCorruptMountPoint](https://docs.microsoft.com/powershell/module/dism/clear-windowscorruptmountpoint).
+For more information, see [Clear-WindowsCorruptMountPoint](https://learn.microsoft.com/powershell/module/dism/clear-windowscorruptmountpoint).
 
 ```shell
 Clear-WindowsCorruptMountPoint
@@ -15,7 +15,7 @@ Clear-WindowsCorruptMountPoint
 ## Dismount-WindowsImage
 
 The **Dismount-WindowsImage** cmdlet either saves or discards the changes to a Windows image and then dismounts the image.
-For more information, see [Dismount-WindowsImage](https://docs.microsoft.com/powershell/module/dism/dismount-windowsimage).
+For more information, see [Dismount-WindowsImage](https://learn.microsoft.com/powershell/module/dism/dismount-windowsimage).
 
 ```shell
 Dismount-WindowsImage -Path "C:\offline" -Discard
@@ -28,7 +28,7 @@ Dismount-WindowsImage -Path "C:\offline" -Save -CheckIntegrity
 ## Expand-WindowsImage
 
 The **Expand-WindowsImage** cmdlet applies an image to a specified location.
-For more information, see [Expand-WindowsImage](https://docs.microsoft.com/powershell/module/dism/expand-windowsimage).
+For more information, see [Expand-WindowsImage](https://learn.microsoft.com/powershell/module/dism/expand-windowsimage).
 
 ```shell
 Expand-WindowsImage -ImagePath "C:\provisioning\images\install.wim" -Index 1 -ApplyPath "D:\" -CheckIntegrity -Verify
@@ -41,7 +41,7 @@ Expand-WindowsImage -ImagePath "C:\provisioning\images\install.wim" -Name "Windo
 ## Export-WindowsImage
 
 The **Export-WindowsImage** cmdlet exports a copy of the specified image to another image file.
-For more information, see [Export-WindowsImage](https://docs.microsoft.com/powershell/module/dism/export-windowsimage).
+For more information, see [Export-WindowsImage](https://learn.microsoft.com/powershell/module/dism/export-windowsimage).
 
 > **Note**\
 > This cmdlet does not support the "recovery" compression type. Use DISM instead.
@@ -57,7 +57,7 @@ Export-WindowsImage -DestinationImagePath "C:\provisioning\images\export\install
 ## Get-AppxProvisionedPackage
 
 The **Get-AppxProvisionedPackage** cmdlet gets information about app packages (`.appx`) in an image that are set to install for each new user.
-For more information, see [Get-AppxProvisionedPackage](https://docs.microsoft.com/powershell/module/dism/get-appxprovisionedpackage).
+For more information, see [Get-AppxProvisionedPackage](https://learn.microsoft.com/powershell/module/dism/get-appxprovisionedpackage).
 
 > **Note**\
 > For information about app packages (`.appx`) that are not provisioned, use the [**Get-AppxPackage**](appx.md#get-appxpackage) cmdlet instead.
@@ -73,7 +73,7 @@ Get-AppxProvisionedPackage -Online
 ## Get-WindowsImage
 
 The **Get-WindowsImage** cmdlet gets information about a Windows image in a WIM or VHD file.
-For more information, see [Get-WindowsImage](https://docs.microsoft.com/powershell/module/dism/get-windowsimage).
+For more information, see [Get-WindowsImage](https://learn.microsoft.com/powershell/module/dism/get-windowsimage).
 
 ```shell
 Get-WindowsImage -ImagePath "C:\provisioning\images\install.wim"
@@ -94,7 +94,7 @@ Get-WindowsImage -Mounted
 ## Mount-WindowsImage
 
 The **Mount-WindowsImage** cmdlet maps a Windows image in a WIM or VHD file to the specified directory so that it is accessible for servicing.
-For more information, see [Mount-WindowsImage](https://docs.microsoft.com/powershell/module/dism/mount-windowsimage).
+For more information, see [Mount-WindowsImage](https://learn.microsoft.com/powershell/module/dism/mount-windowsimage).
 
 ```shell
 Mount-WindowsImage -Path "C:\offline" -ImagePath "C:\provisioning\images\install.wim" -Index 1 -CheckIntegrity
@@ -110,7 +110,7 @@ Mount-WindowsImage -Path "C:\offline" -ImagePath "C:\provisioning\images\install
 ## Repair-WindowsImage
 
 The **Repair-WindowsImage** cmdlet repairs a Windows image in a WIM or VHD file.
-For more information, see [Repair-WindowsImage](https://docs.microsoft.com/powershell/module/dism/repair-windowsimage).
+For more information, see [Repair-WindowsImage](https://learn.microsoft.com/powershell/module/dism/repair-windowsimage).
 
 ```shell
 Repair-WindowsImage -Path 'C:\offline' -CheckHealth
@@ -135,7 +135,7 @@ Repair-WindowsImage -Online -StartComponentCleanup -ResetBase
 ## Split-WindowsImage
 
 The **Split-WindowsImage** cmdlet creates the `.swm` files in the specified directory, naming each file the same as the specified `SplitImagePath`, but with an appended number.
-For more information, see [Split-WindowsImage](https://docs.microsoft.com/powershell/module/dism/split-windowsimage).
+For more information, see [Split-WindowsImage](https://learn.microsoft.com/powershell/module/dism/split-windowsimage).
 
 ```shell
 Split-WindowsImage -ImagePath "C:\provisioning\images\install.wim" -SplitImagePath "C:\provisioning\images\export\install.swm" -FileSize 3072 -CheckIntegrity

--- a/docs/msi.md
+++ b/docs/msi.md
@@ -1,12 +1,12 @@
 # Microsoft Windows Installer (MSI) Commands
 
-A curated list of [Windows Installer](https://docs.microsoft.com/windows/win32/msi/windows-installer-portal) commands.
+A curated list of [Windows Installer](https://learn.microsoft.com/windows/win32/msi/windows-installer-portal) commands.
 The Microsoft Windows Installer service enables better corporate deployment and provides a standard format for component management.
 
 ## Unpacking MSI into Directory (TARGETDIR)
 
 The **TARGETDIR** property specifies the root destination directory for the installation.
-For more information, see [TARGETDIR property](https://docs.microsoft.com/windows/win32/msi/targetdir).
+For more information, see [TARGETDIR property](https://learn.microsoft.com/windows/win32/msi/targetdir).
 
 This should not install the product, but instead simply unpack it into the target directory.
 *[I use this for comparing driver changes in Microsoft Surface driver packages without having to actually install them.](surface-laptop-3)*
@@ -28,7 +28,7 @@ msiexec /a "C:\provisioning\software\surface\SurfaceLaptop3_Win11_22000_23.062.2
 
 | Option            | Meaning                                                                                                                    |
 |:------------------|:---------------------------------------------------------------------------------------------------------------------------|
-| `/a`              | [Administrative Installation](https://docs.microsoft.com/windows/win32/msi/administrative-installation)                    |
+| `/a`              | [Administrative Installation](https://learn.microsoft.com/windows/win32/msi/administrative-installation)                    |
 | `<installer.msi>` | Microsoft Windows Installer package to install.                                                                            |
-| `/passive`        | [Only shows a progress bar.](https://docs.microsoft.com/windows/win32/msi/standard-installer-command-line-options#passive) |
-| `TARGETDIR=`      | [Unpacks the installer into the specified location.](https://docs.microsoft.com/windows/win32/msi/targetdir)               |
+| `/passive`        | [Only shows a progress bar.](https://learn.microsoft.com/windows/win32/msi/standard-installer-command-line-options#passive) |
+| `TARGETDIR=`      | [Unpacks the installer into the specified location.](https://learn.microsoft.com/windows/win32/msi/targetdir)               |

--- a/docs/provisioned-appx-packages/README.md
+++ b/docs/provisioned-appx-packages/README.md
@@ -33,7 +33,7 @@ This is helpful for determining what apps you want a provisioning package to rem
 The Cortana app is one of the apps I like to remove; however, its package name is obscure, unlike the other apps.
 If you want to remove the Cortana app, use the package family name listed below.
 
-**Store Name:** [Cortana](https://apps.microsoft.com/store/detail/cortana/9NFFX4SZZ23L)\
+**Store Name:** [Cortana](https://www.microsoft.com/store/productId/9NFFX4SZZ23L)\
 **Store Data:** [9NFFX4SZZ23L](https://bspmts.mp.microsoft.com/v1/public/catalog/retail/products/9NFFX4SZZ23L/applockerdata)\
 **Display Name:** `Microsoft.549981C3F5F10`\
 **Package Family Name:** `Microsoft.549981C3F5F10_8wekyb3d8bbwe`

--- a/docs/sfc.md
+++ b/docs/sfc.md
@@ -1,6 +1,6 @@
 # System File Checker (SFC) Commands
 
-A curated list of [System File Checker](https://docs.microsoft.com/windows/win32/wfp/system-file-checker) commands.
+A curated list of [System File Checker](https://learn.microsoft.com/windows/win32/wfp/system-file-checker) commands.
 The System File Checker scans the integrity of all protected system files and repairs files with problems when possible.
 
 ## Online Repair

--- a/packages/README.md
+++ b/packages/README.md
@@ -15,4 +15,4 @@ The resulting package is outputted as a `.ppkg` file, along with a `.cat` file.
 The `.cat` file contains basic information about the package, but is generally useless unless you are password protecting or signing your package with a certificate.
 The `.ppkg` file contains all scripts, assets, and binaries and is used to provision a device during or after Windows OOBE.
 
-For more information, see [Provisioning packages for Windows](https://docs.microsoft.com/windows/configuration/provisioning-packages/provisioning-packages).
+For more information, see [Provisioning packages for Windows](https://learn.microsoft.com/windows/configuration/provisioning-packages/provisioning-packages).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,7 @@ The local disk, `Disk 0`, will be wiped during this process.
 *Remove any extra drives and ensure your data is backed up before proceeding, we are not responsible for lost data.*
 
 > **Note**\
-> For legacy [BIOS–based devices](https://docs.microsoft.com/windows-hardware/manufacture/desktop/configure-biosmbr-based-hard-drive-partitions), use [`CreatePartitions-BIOS.txt`](CreatePartitions-BIOS.txt).
+> For legacy [BIOS–based devices](https://learn.microsoft.com/windows-hardware/manufacture/desktop/configure-biosmbr-based-hard-drive-partitions), use [`CreatePartitions-BIOS.txt`](CreatePartitions-BIOS.txt).
 
 ![Windows Setup UEFI Partition Layout](../docs/images/windows-setup/windows-setup-install-location.webp)
 
@@ -23,7 +23,7 @@ The local disk, `Disk 0`, will be wiped during this process.
 
 1. Select **Local Disk** and then select **Next**.
 
-For more information, see [To partition hard drives and prepare to apply images](https://docs.microsoft.com/windows-hardware/manufacture/desktop/configure-uefigpt-based-hard-drive-partitions#to-partition-hard-drives-and-prepare-to-apply-images).
+For more information, see [To partition hard drives and prepare to apply images](https://learn.microsoft.com/windows-hardware/manufacture/desktop/configure-uefigpt-based-hard-drive-partitions#to-partition-hard-drives-and-prepare-to-apply-images).
 
 ## Windows Setup Edition Configuration
 
@@ -35,4 +35,4 @@ The [`EI.cfg`](EI.cfg) configuration file ensures that Windows Setup always asks
 1. Copy the [`EI.cfg`](EI.cfg) configuration file into the `\sources` directory on the Windows installation media.
 1. When using the installation media, Windows Setup will always ask what Windows edition (e.g., Home or Pro) to install.
 
-For more information, see [Windows Setup Edition Configuration and Product ID Files](https://docs.microsoft.com/windows-hardware/manufacture/desktop/windows-setup-edition-configuration-and-product-id-files--eicfg-and-pidtxt).
+For more information, see [Windows Setup Edition Configuration and Product ID Files](https://learn.microsoft.com/windows-hardware/manufacture/desktop/windows-setup-edition-configuration-and-product-id-files--eicfg-and-pidtxt).


### PR DESCRIPTION
# Summary

- Replaces all `https://docs.microsoft.com/` links with `https://learn.microsoft.com/` to match the new Microsoft Learn branding as outlined in #70.
- Updates Microsoft Store links to utilize the short links generated from the Windows 11 Microsoft Store app.

## References

- Resolves #70
