### PR TITLE
Update Surface Laptop 3 drivers list

### DIFF
--- a/docs/msi.md
+++ b/docs/msi.md
@@ -16,14 +16,14 @@ This should not install the product, but instead simply unpack it into the targe
 
 In the first example, the installer is in my shell's current working directory, so it still executes fine.
 The second example explicitly uses the installer's absolute path, so the shell's working directory can be anywhere.
-*I like to put quotes around `<installer.msi>`, but they aren't necessary.*
+*I like to put quotes around `<installer.msi>`, but they are not necessary.*
 
 ```PowerShell
-msiexec /a "SurfaceLaptop3_Intel_Win11_22000_23.102.18472.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
+msiexec /a "SurfaceLaptop3_Intel_Win11_22000_23.111.10140.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
 ```
 
 ```PowerShell
-msiexec /a "C:\provisioning\software\surface\SurfaceLaptop3_Intel_Win11_22000_23.102.18472.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
+msiexec /a "C:\provisioning\software\surface\SurfaceLaptop3_Intel_Win11_22000_23.111.10140.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
 ```
 
 | Option            | Meaning                                                                                                                     |

--- a/docs/msi.md
+++ b/docs/msi.md
@@ -19,11 +19,11 @@ The second example explicitly uses the installer's absolute path, so the shell's
 *I like to put quotes around `<installer.msi>`, but they aren't necessary.*
 
 ```PowerShell
-msiexec /a "SurfaceLaptop3_Intel_Win11_22000_23.091.15598.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
+msiexec /a "SurfaceLaptop3_Intel_Win11_22000_23.101.7094.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
 ```
 
 ```PowerShell
-msiexec /a "C:\provisioning\software\surface\SurfaceLaptop3_Intel_Win11_22000_23.091.15598.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
+msiexec /a "C:\provisioning\software\surface\SurfaceLaptop3_Intel_Win11_22000_23.101.7094.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
 ```
 
 | Option            | Meaning                                                                                                                     |

--- a/docs/msi.md
+++ b/docs/msi.md
@@ -19,11 +19,11 @@ The second example explicitly uses the installer's absolute path, so the shell's
 *I like to put quotes around `<installer.msi>`, but they aren't necessary.*
 
 ```PowerShell
-msiexec /a "SurfaceLaptop3_Intel_Win11_22000_23.101.7094.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
+msiexec /a "SurfaceLaptop3_Intel_Win11_22000_23.102.18472.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
 ```
 
 ```PowerShell
-msiexec /a "C:\provisioning\software\surface\SurfaceLaptop3_Intel_Win11_22000_23.101.7094.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
+msiexec /a "C:\provisioning\software\surface\SurfaceLaptop3_Intel_Win11_22000_23.102.18472.0.msi" /passive TARGETDIR=C:\provisioning\software\surface\unpack
 ```
 
 | Option            | Meaning                                                                                                                     |

--- a/docs/surface-laptop-3/README.md
+++ b/docs/surface-laptop-3/README.md
@@ -15,12 +15,12 @@ A descriptive list of components in the cumulative Surface Laptop 3 firmware and
 | *Field*            | *Data*                                                                                             |
 |:-------------------|:---------------------------------------------------------------------------------------------------|
 | **Device**         | [Surface Laptop 3 with Intel Processor](https://www.microsoft.com/download/details.aspx?id=100429) |
-| **File Name**      | `SurfaceLaptop3_Intel_Win11_22000_23.091.15598.0.msi`                                              |
+| **File Name**      | `SurfaceLaptop3_Intel_Win11_22000_23.101.7094.0.msi`                                               |
 | **Target OS**      | `Windows 11 22000`                                                                                 |
-| **Driver Version** | `23.091.15598.0`                                                                                   |
-| **File Size**      | `625.4 MB`                                                                                         |
-| **Date Published** | 9/15/2023                                                                                          |
-| **Date Signed**    | Monday, September 11, 2023 4:12:36 PM                                                              |
+| **Driver Version** | `23.101.7094.0`                                                                                    |
+| **File Size**      | `626.2 MB`                                                                                         |
+| **Date Published** | 10/13/2023                                                                                         |
+| **Date Signed**    | Thursday, October 5, 2023 6:28:25 PM                                                               |
 
 *"Date Published" represents the last time the file was updated on the Microsoft site,
 so the file may be older than the actual "Date Published".

--- a/docs/surface-laptop-3/README.md
+++ b/docs/surface-laptop-3/README.md
@@ -15,13 +15,16 @@ A descriptive list of components in the cumulative Surface Laptop 3 firmware and
 | *Field*            | *Data*                                                                                             |
 |:-------------------|:---------------------------------------------------------------------------------------------------|
 | **Device**         | [Surface Laptop 3 with Intel Processor](https://www.microsoft.com/download/details.aspx?id=100429) |
-| **File Name**      | `SurfaceLaptop3_Intel_Win11_22000_23.101.7094.0.msi`                                               |
+| **File Name**      | `SurfaceLaptop3_Intel_Win11_22000_23.102.18472.0.msi`                                              |
 | **Target OS**      | `Windows 11 22000`                                                                                 |
-| **Driver Version** | `23.101.7094.0`                                                                                    |
-| **File Size**      | `626.2 MB`                                                                                         |
-| **Date Published** | 10/13/2023                                                                                         |
-| **Date Signed**    | Thursday, October 5, 2023 6:28:25 PM                                                               |
+| **Driver Version** | `23.102.18472.0`                                                                                   |
+| **File Size**      | `627.1 MB`                                                                                         |
+| **Date Published** | 10/24/2023                                                                                         |
+| **Date Signed**    | Friday, October 13, 2023 4:06:36 PM                                                                |
 
 *"Date Published" represents the last time the file was updated on the Microsoft site,
 so the file may be older than the actual "Date Published".
 Instead, look at the "Date Signed" to see when Microsoft signed the file.*
+
+> [!NOTE]  
+> The "Date Signed" is in Eastern Standard Time (EST).

--- a/docs/surface-laptop-3/README.md
+++ b/docs/surface-laptop-3/README.md
@@ -15,12 +15,12 @@ A descriptive list of components in the cumulative Surface Laptop 3 firmware and
 | *Field*            | *Data*                                                                                             |
 |:-------------------|:---------------------------------------------------------------------------------------------------|
 | **Device**         | [Surface Laptop 3 with Intel Processor](https://www.microsoft.com/download/details.aspx?id=100429) |
-| **File Name**      | `SurfaceLaptop3_Intel_Win11_22000_23.102.18472.0.msi`                                              |
+| **File Name**      | `SurfaceLaptop3_Intel_Win11_22000_23.111.10140.0.msi`                                              |
 | **Target OS**      | `Windows 11 22000`                                                                                 |
-| **Driver Version** | `23.102.18472.0`                                                                                   |
-| **File Size**      | `627.1 MB`                                                                                         |
-| **Date Published** | 10/24/2023                                                                                         |
-| **Date Signed**    | Friday, October 13, 2023 4:06:36 PM                                                                |
+| **Driver Version** | `23.111.10140.0`                                                                                   |
+| **File Size**      | `641.4 MB`                                                                                         |
+| **Date Published** | 11/17/2023                                                                                         |
+| **Date Signed**    | Tuesday, November 7, 2023 8:12:00 PM                                                               |
 
 *"Date Published" represents the last time the file was updated on the Microsoft site,
 so the file may be older than the actual "Date Published".

--- a/docs/surface-laptop-3/SurfaceLaptop3Drivers.txt
+++ b/docs/surface-laptop-3/SurfaceLaptop3Drivers.txt
@@ -8,16 +8,14 @@ Device(s): Surface Laptop 3
 List of Included Firmware and Drivers
 ====================================================================================================================
 
-Class              InfName                                 Version         Date      
------              -------                                 -------         ----      
+Class              InfName                                 Version         Date
+-----              -------                                 -------         ----
 Battery            SurfaceBattery.inf                      1.60.139.0      08/22/2019
 Bluetooth          ibtusb.inf                              22.230.0.2      04/26/2023
-CTA Driver Devices MiniCtaDriver.inf                       27.20.100.9621  06/15/2021
-Display            iigd_dch.inf                            27.20.100.9621  06/15/2021
-Display            iigd_dch_d.inf                          27.20.100.9621  06/15/2021
+Display            iigd_dch.inf                            31.0.101.2125   05/24/2023
 Extension          DevicesTelemetryServiceDriver.inf       6.196.139.0     02/16/2023
-Extension          HdBusExt.inf                            27.20.100.9621  06/15/2021
-Extension          iigd_ext_Av.inf                         27.20.100.9621  06/16/2021
+Extension          HdBusExt.inf                            31.0.101.2125   05/24/2023
+Extension          iigd_ext_av.inf                         31.0.101.2125   05/24/2023
 Extension          IntcOED_OemLibPathExt.inf               10.24.245.1     01/19/2023
 Extension          OemExtension.inf                        1952.14.0.1470  12/25/2019
 Extension          RealtekExt.inf                          6.1.0.16        08/17/2021
@@ -49,28 +47,26 @@ HIDClass           SurfaceTconDriver.inf                   3.50.139.0      08/22
 HIDClass           SurfaceVirtualFunctionEnum.inf          1.18.139.0      08/10/2019
 MEDIA              HDXSSTM2.inf                            6.0.9249.2      10/08/2021
 MEDIA              IntcBTAu.inf                            10.24.0.7927    08/02/2022
-MEDIA              IntcDAud.inf                            10.26.0.10      04/16/2021
-MEDIA              IntcDAud.inf                            10.27.0.10      04/16/2021
-MEDIA              IntcDAud.inf                            11.1.0.18       04/16/2021
-MEDIA              IntcDAud.inf                            11.2.0.8        04/16/2021
+MEDIA              IntcDAud.inf                            10.26.0.12      11/21/2021
+MEDIA              IntcDAud.inf                            10.27.0.12      11/21/2021
+MEDIA              IntcDAud.inf                            11.1.0.20       11/21/2021
+MEDIA              IntcDAud.inf                            11.2.0.10       11/21/2021
 MEDIA              IntcDMic.inf                            10.24.0.7927    08/02/2022
 MEDIA              IntcSDW.inf                             10.24.0.7927    08/02/2022
 MEDIA              IntcSST.inf                             10.24.0.7927    08/02/2022
-MEDIA              MSHdaDac.inf                            27.20.100.9621  06/15/2021
+MEDIA              MSHdaDac.inf                            31.0.101.2125   05/24/2023
 Monitor            SurfaceOemPanel.inf                     6.81.139.0      07/15/2021
 Net                msu53cx22x64sta.INF                     1153.9.20.823   08/23/2022
 Net                msu56cx22x64sta.INF                     1156.9.20.823   08/23/2022
 net                Netwtw08.INF                            22.230.0.8      05/09/2023
-SoftwareComponent  cui_dch.inf                             27.20.100.9621  06/15/2021
+SoftwareComponent  cui_dch.inf                             31.0.101.2125   05/24/2023
 SoftwareComponent  iclsClient.inf                          1.66.712.0      12/08/2022
-SoftwareComponent  igcc_dch.inf                            27.20.100.9621  06/15/2021
+SoftwareComponent  igcc_dch.inf                            31.0.101.2125   05/24/2023
 SoftwareComponent  RealtekHSA.inf                          11.0.6000.92    05/29/2018
 System             DetectionVerificationDrv.inf            1.0.2283.0      05/17/2022
 System             DetectionVerificationDrv.inf            1.0.2283.0      05/17/2022
 System             dptf_acpi.inf                           8.6.10401.9906  06/14/2019
 System             dptf_cpu.inf                            8.6.10401.9906  06/14/2019
-System             GSCAuxDriver.inf                        2110.0.9.0      03/03/2021
-System             gscheci.inf                             2110.100.0.1057 03/04/2021
 System             heci.inf                                2251.4.2.0      12/11/2022
 System             iaLPSS2_GPIO2_ICL.inf                   30.100.1916.1   04/15/2019
 System             iaLPSS2_I2C_ICL.inf                     30.100.1916.1   04/15/2019
@@ -82,7 +78,6 @@ System             IceLakePCH-LPSystemNorthpeak.inf        10.1.12.2       07/18
 System             IntcAudioBus.inf                        10.24.0.7927    08/02/2022
 System             IntcOED.inf                             10.24.0.7927    08/02/2022
 System             IntcOED.inf                             10.24.0.7927    08/02/2022
-System             memcntrl.inf                            27.20.100.9621  06/15/2021
 System             SurfaceAcpiNotifyDriver.inf             7.52.139.0      08/22/2019
 System             SurfaceButton.inf                       3.43.139.0      08/22/2019
 System             SurfaceHotPlug.inf                      2.40.139.0      08/22/2019

--- a/docs/surface-laptop-3/SurfaceLaptop3Drivers.txt
+++ b/docs/surface-laptop-3/SurfaceLaptop3Drivers.txt
@@ -11,7 +11,7 @@ List of Included Firmware and Drivers
 Class              InfName                                 Version         Date      
 -----              -------                                 -------         ----      
 Battery            SurfaceBattery.inf                      1.60.139.0      08/22/2019
-Bluetooth          ibtusb.inf                              22.190.0.2      11/08/2022
+Bluetooth          ibtusb.inf                              22.230.0.2      04/26/2023
 CTA Driver Devices MiniCtaDriver.inf                       27.20.100.9621  06/15/2021
 Display            iigd_dch.inf                            27.20.100.9621  06/15/2021
 Display            iigd_dch_d.inf                          27.20.100.9621  06/15/2021
@@ -32,7 +32,7 @@ Firmware           SurfaceKIP.inf                          14.204.139.0    01/27
 Firmware           SurfaceME.inf                           13.0.2101.2     07/08/2022
 Firmware           SurfacePD.inf                           3.6.1.0         07/24/2019
 Firmware           SurfaceRETIMER.inf                      0.42.0.0        03/27/2021
-Firmware           SurfaceSAM.inf                          14.602.139.0    05/09/2022
+Firmware           SurfaceSAM.inf                          14.800.139.0    07/25/2023
 Firmware           SurfaceStorageFwUpdate.inf              5.34.139.0      07/28/2019
 Firmware           SurfaceTCON.inf                         160.35.13.0     06/13/2019
 Firmware           SurfaceTCON.inf                         160.35.15.0     06/13/2019
@@ -60,7 +60,7 @@ MEDIA              MSHdaDac.inf                            27.20.100.9621  06/15
 Monitor            SurfaceOemPanel.inf                     6.81.139.0      07/15/2021
 Net                msu53cx22x64sta.INF                     1153.9.20.823   08/23/2022
 Net                msu56cx22x64sta.INF                     1156.9.20.823   08/23/2022
-net                Netwtw08.INF                            22.190.0.4      11/23/2022
+net                Netwtw08.INF                            22.230.0.8      05/09/2023
 SoftwareComponent  cui_dch.inf                             27.20.100.9621  06/15/2021
 SoftwareComponent  iclsClient.inf                          1.63.1155.2     12/01/2021
 SoftwareComponent  igcc_dch.inf                            27.20.100.9621  06/15/2021

--- a/docs/surface-laptop-3/SurfaceLaptop3Drivers.txt
+++ b/docs/surface-laptop-3/SurfaceLaptop3Drivers.txt
@@ -29,7 +29,7 @@ Extension          SurfaceTouchPenProcessorUpdate.inf      3.208.137.0     02/22
 Extension          SurfaceTouchPenProcessorUpdate.inf      3.208.137.0     02/22/2021
 Firmware           SurfaceCFUOverHid.inf                   2.49.139.0      07/27/2019
 Firmware           SurfaceKIP.inf                          14.204.139.0    01/27/2021
-Firmware           SurfaceME.inf                           13.0.2101.2     07/08/2022
+Firmware           SurfaceME.inf                           13.0.2376.2     07/19/2023
 Firmware           SurfacePD.inf                           3.6.1.0         07/24/2019
 Firmware           SurfaceRETIMER.inf                      0.42.0.0        03/27/2021
 Firmware           SurfaceSAM.inf                          14.800.139.0    07/25/2023
@@ -40,7 +40,7 @@ Firmware           SurfaceThunderbolt4DockFwUpdate.inf     2.26.4.0        03/03
 Firmware           SurfaceTouchFw.inf                      3.0.213.139     08/21/2019
 Firmware           SurfaceTouchFw.inf                      3.0.213.139     08/21/2019
 Firmware           SurfaceTPM.inf                          7.2.2.0         12/03/2020
-Firmware           SurfaceUEFI.inf                         16.103.140.0    08/06/2023
+Firmware           SurfaceUEFI.inf                         17.101.140.0    08/24/2023
 HIDClass           iaPreciseTouch.inf                      2.1.0.59        07/30/2019
 HIDClass           SurfaceDockIntegration.inf              1.24.139.0      07/24/2019
 HIDClass           SurfaceHidMiniDriver.inf                3.31.139.0      10/16/2020
@@ -62,7 +62,7 @@ Net                msu53cx22x64sta.INF                     1153.9.20.823   08/23
 Net                msu56cx22x64sta.INF                     1156.9.20.823   08/23/2022
 net                Netwtw08.INF                            22.230.0.8      05/09/2023
 SoftwareComponent  cui_dch.inf                             27.20.100.9621  06/15/2021
-SoftwareComponent  iclsClient.inf                          1.63.1155.2     12/01/2021
+SoftwareComponent  iclsClient.inf                          1.66.712.0      12/08/2022
 SoftwareComponent  igcc_dch.inf                            27.20.100.9621  06/15/2021
 SoftwareComponent  RealtekHSA.inf                          11.0.6000.92    05/29/2018
 System             DetectionVerificationDrv.inf            1.0.2283.0      05/17/2022
@@ -71,7 +71,7 @@ System             dptf_acpi.inf                           8.6.10401.9906  06/14
 System             dptf_cpu.inf                            8.6.10401.9906  06/14/2019
 System             GSCAuxDriver.inf                        2110.0.9.0      03/03/2021
 System             gscheci.inf                             2110.100.0.1057 03/04/2021
-System             heci.inf                                2145.1.42.0     10/31/2021
+System             heci.inf                                2251.4.2.0      12/11/2022
 System             iaLPSS2_GPIO2_ICL.inf                   30.100.1916.1   04/15/2019
 System             iaLPSS2_I2C_ICL.inf                     30.100.1916.1   04/15/2019
 System             iaLPSS2_SPI_ICL.inf                     30.100.1916.1   04/15/2019


### PR DESCRIPTION
# Summary

- Updated Surface Laptop 3 with Intel Processor drivers list to `23.111.10140.0`.
  - Includes notable update to Intel Graphics, from `27.20.100.9621` to `31.0.101.2125`.
- Minor refinements to the Surface Laptop 3 README.

## Notes

The latest Surface Laptop 3 driver package delivers a significant improvement by finally bringing the Intel Graphics Driver up to date. Previous versions relied on driver `27.20.100.9621`, released in 2021. This new package features the latest driver available as of 2023, `31.0.101.2125`.

## Updates

| Name | OS | Version | Type |
| :--- | :--- | :--- | :--- |
| Surface Laptop 3 with Intel Processor | Windows 11 `22000` |  `23.111.10140.0` | Drivers and Firmware |
